### PR TITLE
[feat]: update DumDum quest for NYC events

### DIFF
--- a/src/views/Campaign_2/index.tsx
+++ b/src/views/Campaign_2/index.tsx
@@ -359,13 +359,24 @@ export default function Campaign() {
 		return (
 			<S.Subheader>
 				<p>
-					The Dumdum trials are here! Unlock the Bronze, Silver, and Gold Dumdum to reveal the ultra-rare Platinum
-					Dumdum. A challenge fit for the ultimate collector. Are you up for it? To complete the quest, you must open
-					this page in the{' '}
+					The DumDum Trials are back! 🗽 Unlock the Bronze, Silver, and Gold DumDums to reveal the ultra-rare Platinum
+					DumDum. You can now complete the quest at our upcoming events:
+					<br />
+					🔹 June 24–25 — Permissionless IV (Industry City, Brooklyn)
+					<br />
+					🔹 June 25–26 — NFT NYC Booth (Times Square) + BazAR Billboard live!
+					<br />
+					🔹 June 27 — La Bodega by PONY (evening drop, location TBA)
+					<br />
+					Open this page in{' '}
 					<a href={'https://wander.app'} target={'_blank'}>
 						Wander
 					</a>{' '}
-					wallet browser.
+					or connect with{' '}
+					<a href={'https://beaconwallet.app'} target={'_blank'}>
+						Beacon
+					</a>{' '}
+					wallet to begin.
 				</p>
 				<S.ProfileWrapper onClick={action} active={active}>
 					<span>{label}</span>
@@ -462,7 +473,7 @@ export default function Campaign() {
 				<S.Wrapper className={'border-wrapper-alt2 fade-in'}>
 					<S.Header>
 						<S.HeaderMain>
-							<h1>DumDum Trials</h1>
+							<h1>DumDum NYC Takeover 🗽</h1>
 						</S.HeaderMain>
 						{subheader}
 						{claimsCount && currentView === 'Main' && (
@@ -496,33 +507,33 @@ export default function Campaign() {
 						<p>Official Rules</p>
 						<br />
 						<p>
-							Quest Period: The ETHDenver Dumdum Quest begins on February 27 at 11:00 AM MST and ends on March 2 at
-							11:00 AM MST. It is open exclusively to participants of the ETHDenver conference. Entries received outside
-							this period will not be considered.
+							Quest Period: The NYC DumDum Quest begins on June 24 at 10:00 AM EDT and runs through June 27 at 11:59 PM
+							EDT. It is open to participants attending Permissionless IV, NFT NYC, and La Bodega events. Entries
+							received outside this period will not be considered.
 						</p>
 						<br />
 						<p>
-							How to Enter: During the Quest Period, participants can enter by completing the designated tasks on the
-							Bazar Quest page at the ETHDenver event. No purchase is necessary to enter. Limit one entry per
-							person/household.
+							How to Enter: During the Quest Period, participants can enter by completing the designated tasks at any of
+							our event locations: Permissionless IV in Industry City, our NFT NYC booth in Times Square, or the La
+							Bodega by PONY evening event. No purchase is necessary to enter. Limit one entry per person/household.
 						</p>
 						<br />
 						<p>
-							Upon completing the tasks, participants must select the “Claim” button to receive the assets directly in
-							their profile. If a winner does not claim their prize before March 2 at 11:00 AM MST, the prize may be
-							forfeited and awarded to an alternate participant. No cash or other substitutions will be provided.
+							Upon completing the tasks, participants must select the "Claim" button to receive the assets directly in
+							their profile. If a winner does not claim their prize before June 26 at 11:59 PM EDT, the prize may be
+							forfeited. No cash or other substitutions will be provided.
 						</p>
 						<br />
 						<p>
-							Dumdum Prize: All participants who complete the quest tasks will receive a Platinum Dumdum, with a total
-							of 5,000 available. The odds of receiving a Platinum Dumdum depend on the total number of eligible
-							participants during the Quest Period. The Bronze, Silver, and Gold Dumdum assets are non-transferable
-							(soulbound) and do not have financial value. The Platinum Dumdum atomic asset is transferable but does not
+							DumDum Prize: All participants who complete the quest tasks will receive a Platinum DumDum, with a total
+							of 5,000 available. The odds of receiving a Platinum DumDum depend on the total number of eligible
+							participants during the Quest Period. The Bronze, Silver, and Gold DumDum assets are non-transferable
+							(soulbound) and do not have financial value. The Platinum DumDum atomic asset is transferable but does not
 							necessarily have financial value.
 						</p>
 						<br />
 						<p>
-							Sponsor Information: This Quest is sponsored by the Bazar team (Centigro LLC). Sponsor’s address: 435
+							Sponsor Information: This Quest is sponsored by the Bazar team (Centigro LLC). Sponsor's address: 435
 							Market ST Souderton, PA 18964. By participating in this Quest, entrants agree to be bound by these
 							Official Rules and the decisions of the Sponsor, which are final and binding in all matters related to the
 							Quest.


### PR DESCRIPTION

Changes
- Updated campaign title to "DumDum NYC Takeover 🗽"
- Updated event information for:
  - Permissionless IV (June 24-25)
  - NFT NYC Booth (June 25-26)
  - La Bodega by PONY (June 27)
- Added Beacon wallet support alongside Wander
- Updated official rules with new dates and event details

Testing
- Verified wallet connection works with both Wander and Beacon
- Tested asset claiming functionality remains unchanged
- Verified rules section displays correctly
