### PR TITLE
feat: refine operation feedback dialogs

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -140,7 +140,13 @@ import { Loading } from 'components/Loading';
 import { MintTransactionReceipt } from 'components/MintTransactionReceipt';
 import { NameArtwork } from 'components/NameArtwork';
 import { NamesCubePreview } from 'components/NamesCubePreview';
-import { OperationOutcome, OperationOutcomeAnnouncement } from 'components/OperationOutcomeAnnouncement';
+import {
+	OperationErrorAlert,
+	OperationExternalLink,
+	OperationOutcome,
+	OperationOutcomeAnnouncement,
+	OperationOutcomeSubject,
+} from 'components/OperationOutcomeAnnouncement';
 import { Pagination } from 'components/Pagination';
 import { PortalIcon } from 'components/PortalIcon';
 import { StateVerification } from 'components/StateVerification';
@@ -9959,7 +9965,9 @@ function OperationDialog({
 										rel="noreferrer"
 										target="_blank"
 									>
-										{short(operation.resume.registration.id)} ↗
+										<OperationExternalLink>
+											{short(operation.resume.registration.id)}
+										</OperationExternalLink>
 									</a>{' '}
 									is already signed.
 								</small>
@@ -10228,24 +10236,31 @@ function OperationDialog({
 				{visiblePhase === 'done' ? (
 					<div className="result success">
 						<OperationOutcome title={resultCopy.title} detail={resultCopy.detail}>
-							{operation.kind === 'sell' ? (
-								asset.image ? (
-									<ArtworkImage
-										alt={`${asset.name} artwork`}
-										className="operation-result-artwork"
-										decoding="async"
-										loading="eager"
-										src={asset.image}
-									/>
-								) : (
-									<span
-										aria-label={`${asset.name} artwork`}
-										className="operation-result-artwork operation-result-artwork-fallback"
-										role="img"
-									>
-										{asset.name.slice(0, 1)}
-									</span>
-								)
+							{operation.kind === 'buy' || operation.kind === 'sell' ? (
+								<OperationOutcomeSubject
+									label={operation.kind === 'buy' ? 'You received' : 'You listed'}
+									title={asset.name}
+									detail={operation.kind === 'sell' ? `${value} AR` : 'One asset'}
+									media={
+										asset.image ? (
+											<ArtworkImage
+												alt={`${asset.name} artwork`}
+												className="operation-outcome-subject-artwork"
+												decoding="async"
+												loading="eager"
+												src={asset.image}
+											/>
+										) : (
+											<span
+												aria-label={`${asset.name} artwork`}
+												className="operation-outcome-subject-artwork operation-outcome-subject-artwork-fallback"
+												role="img"
+											>
+												{asset.name.slice(0, 1)}
+											</span>
+										)
+									}
+								/>
 							) : null}
 						</OperationOutcome>
 						{operation.kind === 'buy' ? (
@@ -10267,7 +10282,7 @@ function OperationDialog({
 										rel="noreferrer"
 										target="_blank"
 									>
-										{short(operation.order.orderId)} ↗
+										<OperationExternalLink>{short(operation.order.orderId)}</OperationExternalLink>
 									</a>
 								</div>
 								<div className="settlement-receipt-links">
@@ -10277,7 +10292,9 @@ function OperationDialog({
 											rel="noreferrer"
 											target="_blank"
 										>
-											Reservation {short(purchaseState.registration.id)} ↗
+											<OperationExternalLink>
+												Reservation {short(purchaseState.registration.id)}
+											</OperationExternalLink>
 										</a>
 									) : null}
 									{purchaseState?.payment?.id ? (
@@ -10286,7 +10303,9 @@ function OperationDialog({
 											rel="noreferrer"
 											target="_blank"
 										>
-											Payment {short(purchaseState.payment.id)} ↗
+											<OperationExternalLink>
+												Payment {short(purchaseState.payment.id)}
+											</OperationExternalLink>
 										</a>
 									) : null}
 								</div>
@@ -10303,13 +10322,15 @@ function OperationDialog({
 								</div>
 								<div className="settlement-receipt-links">
 									<a href={transactionExplorerUrl(transaction.id)} rel="noreferrer" target="_blank">
-										Transaction {short(transaction.id)} ↗
+										<OperationExternalLink>
+											Transaction {short(transaction.id)}
+										</OperationExternalLink>
 									</a>
 								</div>
 							</div>
 						) : transaction ? (
 							<a href={transactionExplorerUrl(transaction.id)} rel="noreferrer" target="_blank">
-								View transaction {short(transaction.id)} ↗
+								<OperationExternalLink>View transaction {short(transaction.id)}</OperationExternalLink>
 							</a>
 						) : null}
 						<Button
@@ -10348,7 +10369,9 @@ function OperationDialog({
 											rel="noreferrer"
 											target="_blank"
 										>
-											{short(operation.order.orderId)} ↗
+											<OperationExternalLink>
+												{short(operation.order.orderId)}
+											</OperationExternalLink>
 										</a>
 									</div>
 									<div className="settlement-receipt-links">
@@ -10358,7 +10381,9 @@ function OperationDialog({
 												rel="noreferrer"
 												target="_blank"
 											>
-												Reservation {short(purchaseState.registration.id)} ↗
+												<OperationExternalLink>
+													Reservation {short(purchaseState.registration.id)}
+												</OperationExternalLink>
 											</a>
 										) : null}
 										{purchaseState?.payment?.id ? (
@@ -10367,7 +10392,9 @@ function OperationDialog({
 												rel="noreferrer"
 												target="_blank"
 											>
-												Payment {short(purchaseState.payment.id)} ↗
+												<OperationExternalLink>
+													Payment {short(purchaseState.payment.id)}
+												</OperationExternalLink>
 											</a>
 										) : null}
 									</div>
@@ -10432,12 +10459,7 @@ function OperationDialog({
 }
 
 export function AtomicOperationErrorAlert({ message }: { message: string }) {
-	return (
-		<div className="result-alert" role="alert">
-			<h3>Could not complete this action</h3>
-			<p>{message}</p>
-		</div>
-	);
+	return <OperationErrorAlert title="Could not complete this action" message={message} />;
 }
 
 function collectionKindLabel(collection: Collection) {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2267,13 +2267,7 @@ function Header() {
 										</div>
 									</section>
 								) : null}
-								{market.error ? (
-									<ErrorPanel
-										message={market.error}
-										onRetry={market.retry}
-										retryLabel="Retry marketplace"
-									/>
-								) : null}
+								{market.error ? <ErrorPanel message={market.error} onRetry={market.retry} /> : null}
 								{!market.loading &&
 								!market.error &&
 								!atomicIndexSearchPending &&
@@ -4071,13 +4065,7 @@ function Home() {
 									</div>
 								) : null}
 							</div>
-							{market.error ? (
-								<ErrorPanel
-									message={market.error}
-									onRetry={market.retry}
-									retryLabel="Retry collections"
-								/>
-							) : null}
+							{market.error ? <ErrorPanel message={market.error} onRetry={market.retry} /> : null}
 							{homeTab === 'discover' && portableHomeListingsFailure ? (
 								<ErrorPanel
 									message={marketplaceRequestFailureMessage(
@@ -4085,7 +4073,6 @@ function Home() {
 										portableHomeListingsFailure.kind
 									)}
 									onRetry={() => setPortableHomeRetry((current) => current + 1)}
-									retryLabel="Retry public listings"
 								/>
 							) : null}
 							{homeTab === 'discover' && partialTokenCollection ? (
@@ -4613,21 +4600,17 @@ function HomeActivityPanel({ collections, marketLoading }: { collections: Collec
 			</div>
 			{error ? (
 				events.length ? (
-					<div className="collection-source-notice home-activity-partial-notice">
+					<div className="collection-source-notice home-activity-partial-notice retry-notice">
 						<span role="status">
-							Some activity sources could not be refreshed. Showing {events.length.toLocaleString()}{' '}
-							indexed {events.length === 1 ? 'event' : 'events'} already loaded. {error}
+							Compute hasn’t completed yet. Please try again. Showing {events.length.toLocaleString()}{' '}
+							indexed {events.length === 1 ? 'event' : 'events'} already loaded.
 						</span>
 						<Button className="with-icon" onClick={retryActivity} size="custom" type="button">
-							<RefreshCw className="ui-icon ui-icon--sm" aria-hidden="true" /> Retry activity
+							<RefreshCw className="ui-icon ui-icon--sm" aria-hidden="true" /> Retry
 						</Button>
 					</div>
 				) : (
-					<ErrorPanel
-						message={`Global activity could not be loaded. ${error}`}
-						onRetry={retryActivity}
-						retryLabel="Retry activity"
-					/>
+					<ErrorPanel message={`Global activity could not be loaded. ${error}`} onRetry={retryActivity} />
 				)
 			) : null}
 			<MarketActivityList
@@ -6054,7 +6037,7 @@ function CollectionView() {
 	if (!collection && market.error)
 		return (
 			<RouteState title="Collection unavailable">
-				<ErrorPanel message={market.error} onRetry={market.retry} retryLabel="Retry collection index" />
+				<ErrorPanel message={market.error} onRetry={market.retry} />
 			</RouteState>
 		);
 	if (!collection)
@@ -6365,8 +6348,8 @@ function CollectionView() {
 				</div>
 			) : null}
 			{activityState.error ? (
-				<div className="inline-error">
-					<span role="alert">{activityState.error}</span>
+				<div className="inline-error retry-notice">
+					<span role="status">Compute hasn’t completed yet. Please try again.</span>
 					<Button
 						className="with-icon"
 						size="custom"
@@ -6380,14 +6363,9 @@ function CollectionView() {
 				</div>
 			) : null}
 			{!listedOnly && !cardPricesLoading && (cardPricesFailure || visibleUnavailablePrices > 0) ? (
-				<div className="inline-error">
+				<div className="inline-error retry-notice">
 					<span role="status">
-						{cardPricesFailure
-							? marketplaceRequestFailureMessage(cardPricesFailure.source, cardPricesFailure.kind)
-							: marketplaceRequestFailureMessage(
-									'compute',
-									visibleRateLimitedPrices ? 'rate-limited' : 'unavailable'
-							  )}
+						Compute hasn’t completed yet. Please try again.
 						{!cardPricesFailure && visibleUnavailablePrices
 							? ` ${visibleUnavailablePrices.toLocaleString()} visible ${
 									visibleUnavailablePrices === 1 ? 'price remains' : 'prices remain'
@@ -6396,21 +6374,16 @@ function CollectionView() {
 					</span>
 					<Button className="with-icon" type="button" onClick={retryCardPrices} size="custom">
 						<RefreshCw className="ui-icon ui-icon--sm" aria-hidden="true" />
-						{cardPricesFailure?.kind === 'rate-limited' || visibleRateLimitedPrices
-							? 'Retry later'
-							: 'Retry prices'}
+						Retry
 					</Button>
 				</div>
 			) : null}
 			{listedOnly && !activityState.loading && !activityState.error && activityState.failures ? (
-				<div className="inline-error">
+				<div className="inline-error retry-notice">
 					<span role="status">
 						{listingRetrying
 							? 'Rechecking only the listing candidates that were unavailable.'
-							: marketplaceRequestFailureMessage(
-									'compute',
-									activityState.rateLimited ? 'rate-limited' : 'unavailable'
-							  )}{' '}
+							: 'Compute hasn’t completed yet. Please try again.'}{' '}
 						{activityState.failures.toLocaleString()} listing{' '}
 						{activityState.failures === 1 ? 'candidate remains' : 'candidates remain'} unavailable. Resolved
 						listings remain visible.
@@ -6425,24 +6398,16 @@ function CollectionView() {
 							window.requestAnimationFrame(() => collectionStatusRef.current?.focus());
 						}}
 					>
-						<RefreshCw className="ui-icon ui-icon--sm" aria-hidden="true" />{' '}
-						{listingRetrying
-							? 'Retrying…'
-							: activityState.rateLimited
-							? 'Retry later'
-							: 'Retry unavailable'}
+						<RefreshCw className="ui-icon ui-icon--sm" aria-hidden="true" /> Retry
 					</Button>
 				</div>
 			) : null}
 			{listedOnly && (recentOrderState.loading || recentOrderState.error) ? (
-				<div className={recentOrderState.error ? 'inline-error' : 'collection-source-notice'}>
+				<div className={recentOrderState.error ? 'inline-error retry-notice' : 'collection-source-notice'}>
 					<span role="status">
 						{recentOrderState.loading
 							? 'Ordering live listings by their latest indexed market activity…'
-							: `${marketplaceRequestFailureMessage(
-									'index',
-									recentOrderState.error!
-							  )} Resolved listings are shown in Default order.`}
+							: 'Compute hasn’t completed yet. Please try again. Resolved listings are shown in Default order.'}
 					</span>
 					{recentOrderState.error ? (
 						<Button
@@ -6454,7 +6419,7 @@ function CollectionView() {
 								window.requestAnimationFrame(() => collectionStatusRef.current?.focus());
 							}}
 						>
-							<RefreshCw className="ui-icon ui-icon--sm" aria-hidden="true" /> Retry recent order
+							<RefreshCw className="ui-icon ui-icon--sm" aria-hidden="true" /> Retry
 						</Button>
 					) : null}
 				</div>
@@ -6620,15 +6585,13 @@ function CollectionView() {
 			) : null}
 			{moreState.error ? (
 				<div
-					className="inline-error"
+					className="inline-error retry-notice"
 					ref={(node) => {
 						moreOutcomeRef.current = node;
 					}}
 					tabIndex={-1}
 				>
-					<span role="alert">
-						More {collection.kind === 'tokens' ? 'tokens' : 'names'} could not be loaded: {moreState.error}
-					</span>
+					<span role="status">Compute hasn’t completed yet. Please try again.</span>
 					<Button
 						className="with-icon"
 						size="custom"
@@ -6638,8 +6601,7 @@ function CollectionView() {
 							window.requestAnimationFrame(() => collectionStatusRef.current?.focus());
 						}}
 					>
-						<RefreshCw className="ui-icon ui-icon--sm" aria-hidden="true" /> Retry{' '}
-						{collection.kind === 'tokens' ? 'tokens' : 'names'}
+						<RefreshCw className="ui-icon ui-icon--sm" aria-hidden="true" /> Retry
 					</Button>
 				</div>
 			) : null}
@@ -6748,7 +6710,6 @@ function CollectionResultStatus({ message }: { message: string }) {
 function CollectionIndexNotice({
 	collection,
 	checking,
-	directlyVerified = false,
 	onRetry,
 }: {
 	collection: Collection;
@@ -6757,27 +6718,12 @@ function CollectionIndexNotice({
 	onRetry(): void;
 }) {
 	if (collection.indexSource !== 'compiled-fallback') return null;
-	const tokenIndex = collection.kind === 'tokens';
 	const message = checking
-		? tokenIndex
-			? directlyVerified
-				? 'Checking token discovery. This token remains available directly from live state through the selected gateway.'
-				: 'Checking token discovery. The configured token remains available; ownership, orders, and balances are still computed live through the selected gateway.'
-			: 'Checking this collection’s live asset index. Its bundled index remains available; ownership and orders are still computed live through the selected gateway.'
-		: tokenIndex
-		? directlyVerified
-			? 'This token was read directly from live state and may not appear in collection browsing while token discovery is unavailable.'
-			: 'Token discovery is unavailable. Showing the configured token only; ownership, orders, and balances are still computed live through the selected gateway.'
-		: 'This collection’s live asset index is unavailable. Showing its last published index; ownership and orders are still computed live through the selected gateway.';
-	const compactMessage = tokenIndex
-		? directlyVerified
-			? `${checking ? 'Checking discovery' : 'Discovery unavailable'}; live token state remains available.`
-			: `${checking ? 'Checking discovery' : 'Showing the configured token'}; balances and orders remain live.`
-		: `${
-				checking ? 'Checking the published index' : 'Using the published index'
-		  }; ownership and orders remain live.`;
+		? 'Checking compute. This page remains available while the check finishes.'
+		: 'Compute hasn’t completed yet. Please try again.';
+	const compactMessage = checking ? 'Checking compute…' : 'Compute hasn’t completed yet. Please try again.';
 	return (
-		<div className="collection-source-notice collection-index-notice">
+		<div className="collection-source-notice collection-index-notice retry-notice">
 			<span role="status">
 				<span aria-hidden="true" className="collection-index-message-full">
 					{message}
@@ -6789,7 +6735,7 @@ function CollectionIndexNotice({
 			</span>
 			<Button
 				aria-disabled={checking}
-				aria-label={checking ? 'Checking collection index' : 'Retry collection index'}
+				aria-label="Retry"
 				className="with-icon"
 				size="custom"
 				type="button"
@@ -6799,10 +6745,10 @@ function CollectionIndexNotice({
 			>
 				<RefreshCw className="ui-icon ui-icon--sm" aria-hidden="true" />
 				<span aria-hidden="true" className="collection-index-action-full">
-					{checking ? 'Checking collection index…' : 'Retry collection index'}
+					Retry
 				</span>
 				<span aria-hidden="true" className="collection-index-action-compact">
-					{checking ? 'Checking…' : 'Retry'}
+					Retry
 				</span>
 			</Button>
 		</div>
@@ -6960,7 +6906,7 @@ function CollectionActivityView() {
 	if (!collection && market.error)
 		return (
 			<RouteState title="Activity unavailable">
-				<ErrorPanel message={market.error} onRetry={market.retry} retryLabel="Retry collection index" />
+				<ErrorPanel message={market.error} onRetry={market.retry} />
 			</RouteState>
 		);
 	if (!collection)
@@ -7015,7 +6961,6 @@ function CollectionActivityView() {
 						activityRunMode.current = 'retry';
 						setRetry((value) => value + 1);
 					}}
-					retryLabel="Retry activity"
 				/>
 			) : null}
 			<MarketActivityList
@@ -7628,7 +7573,7 @@ function AssetDetailLoadingShell({
 					</div>
 				</header>
 				{error ? (
-					<ErrorPanel message={error} onRetry={onRetry} retryLabel="Retry live state" />
+					<ErrorPanel message={error} onRetry={onRetry} />
 				) : (
 					<div aria-live="polite" className="state-verification asset-loading-verification" role="status">
 						<span aria-hidden="true" /> Computing current state…
@@ -7756,7 +7701,7 @@ function AssetDetailLoadingShell({
 							<span>Supply 1</span>
 						</div>
 						{error ? (
-							<ErrorPanel message={error} onRetry={onRetry} retryLabel="Retry live state" />
+							<ErrorPanel message={error} onRetry={onRetry} />
 						) : (
 							<div
 								aria-live="polite"
@@ -8424,13 +8369,13 @@ function AssetView() {
 	if (!collection && market.error)
 		return (
 			<RouteState title="Asset unavailable">
-				<ErrorPanel message={market.error} onRetry={market.retry} retryLabel="Retry collection index" />
+				<ErrorPanel message={market.error} onRetry={market.retry} />
 			</RouteState>
 		);
 	if (!collection && directAtomicRoute && error)
 		return (
 			<RouteState title="Asset unavailable">
-				<ErrorPanel message={detailError ?? error} onRetry={load} retryLabel="Retry live state" />
+				<ErrorPanel message={detailError ?? error} onRetry={load} />
 			</RouteState>
 		);
 	if (!collection)
@@ -8457,7 +8402,7 @@ function AssetView() {
 	if (!asset && error)
 		return (
 			<RouteState title="Asset unavailable" backTo={`/collection/${collection.id}`} backLabel={collection.name}>
-				<ErrorPanel message={detailError ?? error} onRetry={load} retryLabel="Retry live state" />
+				<ErrorPanel message={detailError ?? error} onRetry={load} />
 			</RouteState>
 		);
 	if (!asset && !loading)
@@ -8652,7 +8597,7 @@ function AssetView() {
 							failed={Boolean(error)}
 						/>
 						{loading ? <Loading label="Computing current state…" /> : null}
-						{error ? <ErrorPanel message={error} onRetry={load} retryLabel="Retry live state" /> : null}
+						{error ? <ErrorPanel message={error} onRetry={load} /> : null}
 						{state ? (
 							<section aria-busy={operationIsBusy} className="asset-commerce-card">
 								<div className="asset-market-stats">
@@ -8965,12 +8910,10 @@ function AssetView() {
 								/>
 							) : null}
 							{activityError ? (
-								<div className="inline-error" role={assetActivity.length ? 'status' : 'alert'}>
+								<div className="inline-error retry-notice" role="status">
 									<span>
-										Market history could not be read.{' '}
-										{assetActivity.length
-											? `Previously loaded events remain visible. ${activityError}`
-											: activityError}
+										Compute hasn’t completed yet. Please try again.{' '}
+										{assetActivity.length ? 'Previously loaded events remain visible.' : ''}
 									</span>
 									<Button
 										className="with-icon"
@@ -8978,7 +8921,7 @@ function AssetView() {
 										size="custom"
 										type="button"
 									>
-										<RefreshCw className="ui-icon ui-icon--sm" aria-hidden="true" /> Retry history
+										<RefreshCw className="ui-icon ui-icon--sm" aria-hidden="true" /> Retry
 									</Button>
 								</div>
 							) : null}
@@ -10114,12 +10057,12 @@ function OperationDialog({
 							) : null}
 							{operation.kind === 'buy' ? (
 								<div
-									className={quoteError ? 'inline-error' : 'quote-check-action'}
-									role={quoteError ? 'alert' : undefined}
+									className={quoteError ? 'inline-error retry-notice' : 'quote-check-action'}
+									role={quoteError ? 'status' : undefined}
 								>
 									<span>
 										{quoteError
-											? 'The network cost could not be checked.'
+											? 'Compute hasn’t completed yet. Please try again.'
 											: purchaseQuote
 											? 'Costs checked.'
 											: 'Checking wallet balance and network fees…'}
@@ -10134,12 +10077,7 @@ function OperationDialog({
 											if (purchaseQuote || quoteError) setQuoteRetry((current) => current + 1);
 										}}
 									>
-										<RefreshCw className="ui-icon ui-icon--sm" aria-hidden="true" />{' '}
-										{quoteError
-											? 'Retry cost check'
-											: purchaseQuote
-											? 'Recheck cost'
-											: 'Checking cost…'}
+										<RefreshCw className="ui-icon ui-icon--sm" aria-hidden="true" /> Retry
 									</Button>
 								</div>
 							) : null}

--- a/src/app/FungibleAssetView.tsx
+++ b/src/app/FungibleAssetView.tsx
@@ -1259,12 +1259,10 @@ export function FungibleAssetView({
 									</div>
 								</div>
 								{activityError ? (
-									<div className="inline-error" role={activity.length ? 'status' : 'alert'}>
+									<div className="inline-error retry-notice" role="status">
 										<span>
-											Market history could not be read.{' '}
-											{activity.length
-												? `Previously loaded events remain visible. ${activityError}`
-												: activityError}
+											Compute hasn’t completed yet. Please try again.{' '}
+											{activity.length ? 'Previously loaded events remain visible.' : ''}
 										</span>
 										<Button
 											className="with-icon"
@@ -2959,8 +2957,8 @@ function FungibleOperationDialog({
 									) : null}
 									{matchedOrders.length ? (
 										quoteState === 'error' ? (
-											<div className="inline-error" role="alert">
-												<span>Live fees and wallet balance could not be checked.</span>
+											<div className="inline-error retry-notice" role="status">
+												<span>Compute hasn’t completed yet. Please try again.</span>
 												<Button
 													aria-describedby={quoteStatusId}
 													className="with-icon"

--- a/src/app/FungibleAssetView.tsx
+++ b/src/app/FungibleAssetView.tsx
@@ -62,7 +62,13 @@ import { ConnectWalletButton } from 'components/ConnectWalletButton';
 import { ErrorPanel } from 'components/ErrorPanel';
 import { Loading } from 'components/Loading';
 import { MarketActivityList } from 'components/MarketActivityList';
-import { OperationOutcome, OperationOutcomeAnnouncement } from 'components/OperationOutcomeAnnouncement';
+import {
+	OperationErrorAlert,
+	OperationExternalLink,
+	OperationOutcome,
+	OperationOutcomeAnnouncement,
+	OperationOutcomeSubject,
+} from 'components/OperationOutcomeAnnouncement';
 import { type SegmentedTab, SegmentedTabs } from 'components/SegmentedTabs';
 import { TokenAvatar } from 'components/TokenAvatar';
 import { TokenPriceChart, type TokenPricePoint } from 'components/TokenPriceChart';
@@ -3114,10 +3120,36 @@ function FungibleOperationDialog({
 				) : null}
 				{phase === 'done' ? (
 					<div className="result success">
-						<OperationOutcome title={outcomeTitle} detail={outcomeDetail} />
+						<OperationOutcome title={outcomeTitle} detail={outcomeDetail}>
+							{operation.kind === 'buy' || operation.kind === 'sell' ? (
+								<OperationOutcomeSubject
+									label={operation.kind === 'buy' ? 'You received' : 'You listed'}
+									title={
+										operation.kind === 'buy'
+											? tokenLabel(completedPurchaseQuantity.toString(), state)
+											: enteredQuantity
+											? tokenLabel(enteredQuantity.toString(), state)
+											: asset.name
+									}
+									detail={
+										operation.kind === 'sell' && listingQuote
+											? `${listingQuote} AR total`
+											: asset.name
+									}
+									media={
+										<TokenAvatar
+											className="operation-outcome-token-avatar"
+											image={asset.image}
+											loading="eager"
+											ticker={state.ticker || asset.ticker || asset.name}
+										/>
+									}
+								/>
+							) : null}
+						</OperationOutcome>
 						{transaction && operation.kind !== 'transfer' ? (
 							<a href={transactionExplorerUrl(transaction.id)} rel="noreferrer" target="_blank">
-								View transaction {short(transaction.id)} ↗
+								<OperationExternalLink>View transaction {short(transaction.id)}</OperationExternalLink>
 							</a>
 						) : null}
 						{operation.kind === 'buy' ? (
@@ -3140,7 +3172,9 @@ function FungibleOperationDialog({
 								</div>
 								<div className="settlement-receipt-links">
 									<a href={transactionExplorerUrl(transaction.id)} rel="noreferrer" target="_blank">
-										Transaction {short(transaction.id)} ↗
+										<OperationExternalLink>
+											Transaction {short(transaction.id)}
+										</OperationExternalLink>
 									</a>
 								</div>
 							</div>
@@ -3242,7 +3276,9 @@ function FungibleOperationDialog({
 													rel="noreferrer"
 													target="_blank"
 												>
-													Reservation {short(activePurchase.registration.id)} ↗
+													<OperationExternalLink>
+														Reservation {short(activePurchase.registration.id)}
+													</OperationExternalLink>
 												</a>
 											) : null}
 											{activePurchase?.payment?.id ? (
@@ -3251,7 +3287,9 @@ function FungibleOperationDialog({
 													rel="noreferrer"
 													target="_blank"
 												>
-													Payment {short(activePurchase.payment.id)} ↗
+													<OperationExternalLink>
+														Payment {short(activePurchase.payment.id)}
+													</OperationExternalLink>
 												</a>
 											) : null}
 										</div>
@@ -3370,12 +3408,7 @@ function FungibleOperationDialog({
 }
 
 export function FungibleOperationErrorAlert({ message }: { message: string }) {
-	return (
-		<div className="result-alert" role="alert">
-			<h3>Could not complete this action</h3>
-			<p>{message}</p>
-		</div>
-	);
+	return <OperationErrorAlert title="Could not complete this action" message={message} />;
 }
 
 export function MatchedListingsReview({

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -4529,10 +4529,21 @@ input:focus {
 	color: var(--negative);
 	font-size: var(--type-body);
 }
-.inline-error-actions {
-	display: flex;
-	flex: none;
-	gap: 8px;
+.error-panel.retry-notice,
+.inline-error.retry-notice,
+.collection-source-notice.retry-notice,
+.my-assets-heading-status.retry-notice {
+	border: 1px solid var(--line);
+	background: var(--surface-subtle);
+	color: var(--ink);
+}
+.my-assets-heading-status.retry-notice {
+	padding: var(--space-3) var(--space-4);
+	border-radius: 10px;
+}
+.retry-notice .with-icon > .ui-icon,
+.retry-notice-action > .ui-icon {
+	color: var(--retry-icon);
 }
 .collection-source-notice {
 	display: flex;
@@ -6676,9 +6687,6 @@ body input:focus-visible {
 	.pending-operation-notice {
 		align-items: stretch;
 		flex-direction: column;
-	}
-	.inline-error-actions {
-		flex-wrap: wrap;
 	}
 	.site-footer-content {
 		align-items: flex-start;

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -5478,6 +5478,76 @@ input:focus {
 	display: grid;
 	gap: 8px;
 }
+.result-status-heading {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 10px;
+}
+.result-status-icon {
+	width: 34px;
+	height: 34px;
+	stroke-width: 1.6;
+}
+.result.success .result-status-icon {
+	color: var(--positive-text);
+}
+.result.error .result-status-icon {
+	color: var(--warning-text);
+}
+.operation-external-link-label {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+}
+.operation-external-link-label .ui-icon {
+	width: 15px;
+	height: 15px;
+}
+.operation-outcome-subject {
+	min-width: 0;
+	display: flex;
+	align-items: center;
+	gap: 14px;
+}
+.operation-outcome-subject-media {
+	width: 72px;
+	height: 72px;
+	flex: 0 0 72px;
+}
+.operation-outcome-subject-artwork {
+	width: 100%;
+	height: 100%;
+	display: grid;
+	place-items: center;
+	border: 1px solid var(--line);
+	border-radius: 9px;
+	background: var(--panel);
+	object-fit: cover;
+}
+.operation-outcome-subject-artwork-fallback {
+	color: var(--muted);
+	font-size: var(--type-display);
+}
+.operation-outcome-token-avatar {
+	--token-avatar-size: 72px;
+}
+.operation-outcome-subject-copy {
+	min-width: 0;
+	display: grid;
+	gap: 3px;
+}
+.operation-outcome-subject-copy > span,
+.operation-outcome-subject-copy > small {
+	color: var(--muted);
+	font-size: var(--type-small);
+}
+.operation-outcome-subject-copy > strong {
+	overflow-wrap: anywhere;
+	color: var(--ink);
+	font-size: 1.05rem;
+	font-weight: 500;
+}
 .result-alert p,
 .result.error > p {
 	color: var(--muted);
@@ -9415,6 +9485,64 @@ body input:focus-visible {
 	border-radius: 0;
 	box-shadow: -18px 0 52px var(--shadow-strong);
 	transform-origin: right center;
+}
+.operation-side-panel .operation-summary,
+.operation-side-panel .settlement-receipt,
+.operation-side-panel .settlement-error-detail,
+.operation-side-panel .trade-balance,
+.operation-side-panel .trade-quote,
+.operation-side-panel .cancel-summary,
+.operation-side-panel .batch-quote,
+.operation-side-panel .matched-listings,
+.operation-side-panel .purchase-route {
+	padding: 0;
+	border: 0;
+	border-radius: 0;
+	background: var(--transparent);
+}
+.operation-side-panel .settlement-error-detail {
+	margin-inline: 0;
+}
+.operation-side-panel .batch-quote {
+	gap: 12px 20px;
+	overflow: visible;
+}
+.operation-side-panel .batch-quote > div,
+.operation-side-panel .batch-quote > div:nth-child(n) {
+	padding: 0;
+	border: 0;
+}
+.operation-side-panel .purchase-settlement-receipt {
+	gap: 0;
+	overflow: visible;
+}
+.operation-side-panel .purchase-settlement-receipt .settlement-receipt-amount,
+.operation-side-panel .settlement-receipt-facts,
+.operation-side-panel .receipt-proof-links {
+	padding-inline: 0;
+}
+.operation-side-panel .purchase-settlement-receipt .settlement-receipt-amount,
+.operation-side-panel .settlement-receipt-facts > div + div,
+.operation-side-panel .settlement-receipt-links {
+	border: 0;
+}
+.operation-side-panel .settlement-receipt-links {
+	padding-top: 0;
+}
+.operation-side-panel .receipt-proof-links a {
+	padding-inline: 0;
+	border: 0;
+	border-radius: 0;
+	background: var(--transparent);
+}
+.operation-side-panel .receipt-proof-links a:hover {
+	background: var(--surface-hover);
+}
+.operation-side-panel .matched-listings-heading,
+.operation-side-panel .matched-listings ul,
+.operation-side-panel .purchase-route summary,
+.operation-side-panel .purchase-route li {
+	padding-inline: 0;
 }
 .operation-panel-backdrop.dialog-backdrop-hiding .operation-side-panel {
 	filter: none;

--- a/src/app/styles.ts
+++ b/src/app/styles.ts
@@ -51,6 +51,7 @@ export const GlobalStyle = createGlobalStyle`
     --warning-text: ${(props) => props.theme.colors.global.warningText};
     --warning-surface: ${(props) => props.theme.colors.global.warningSurface};
     --warning-border: ${(props) => props.theme.colors.global.warningBorder};
+    --retry-icon: ${(props) => props.theme.colors.global.retryIcon};
     --notice-text: ${(props) => props.theme.colors.global.noticeText};
     --notice-surface: ${(props) => props.theme.colors.global.noticeSurface};
     --event-purple: ${(props) => props.theme.colors.global.eventPurple};

--- a/src/components/ErrorPanel.tsx
+++ b/src/components/ErrorPanel.tsx
@@ -3,20 +3,14 @@ import { RefreshCw } from 'lucide-react';
 import { ArCurrencyText, formatArCurrencyText } from './ArCurrencyLabel';
 import { Button } from './Button';
 
-export function ErrorPanel({
-	message,
-	onRetry,
-	retryLabel = 'Retry',
-}: {
-	message: string;
-	onRetry?: () => void;
-	retryLabel?: string;
-}) {
+export function ErrorPanel({ message, onRetry }: { message: string; onRetry?: () => void }) {
+	const retryMessage = onRetry ? 'Please try again.' : message;
+	const heading = onRetry ? 'Compute hasn’t completed yet' : 'Unable to load';
 	return (
-		<div className="error-panel">
-			<strong>Unable to load</strong>
-			<span aria-label={formatArCurrencyText(`Unable to load. ${message}`)} role="alert">
-				<ArCurrencyText>{message}</ArCurrencyText>
+		<div className={`error-panel${onRetry ? ' retry-notice' : ''}`}>
+			<strong>{heading}</strong>
+			<span aria-label={formatArCurrencyText(`${heading}. ${retryMessage}`)} role={onRetry ? 'status' : 'alert'}>
+				<ArCurrencyText>{retryMessage}</ArCurrencyText>
 			</span>
 			{onRetry ? (
 				<Button
@@ -26,7 +20,7 @@ export function ErrorPanel({
 						document.getElementById('main-content')?.focus({ preventScroll: true });
 					}}
 				>
-					<RefreshCw className="ui-icon ui-icon--sm" aria-hidden="true" /> {retryLabel}
+					<RefreshCw className="ui-icon ui-icon--sm" aria-hidden="true" /> Retry
 				</Button>
 			) : null}
 		</div>

--- a/src/components/OperationOutcomeAnnouncement.test.ts
+++ b/src/components/OperationOutcomeAnnouncement.test.ts
@@ -2,7 +2,11 @@ import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
-import { OperationOutcome, OperationOutcomeAnnouncement } from './OperationOutcomeAnnouncement';
+import {
+	OperationOutcome,
+	OperationOutcomeAnnouncement,
+	OperationOutcomeSubject,
+} from './OperationOutcomeAnnouncement';
 
 describe('operation outcome announcements', () => {
 	it('announces only the concise completed outcome', () => {
@@ -43,5 +47,20 @@ describe('operation outcome announcements', () => {
 		);
 		expect(outcome.indexOf('Listing is live')).toBeLessThan(outcome.indexOf('catsun artwork'));
 		expect(outcome.indexOf('catsun artwork')).toBeLessThan(outcome.indexOf('catsun is offered'));
+	});
+
+	it('names the item or value received in a completed outcome', () => {
+		const subject = renderToStaticMarkup(
+			React.createElement(OperationOutcomeSubject, {
+				label: 'You received',
+				title: '0.11 AR',
+				detail: 'For tSteelBlue',
+				media: React.createElement('img', { alt: 'tSteelBlue artwork', src: '/tsteelblue.png' }),
+			})
+		);
+		expect(subject).toContain('You received');
+		expect(subject).toContain('tSteelBlue artwork');
+		expect(subject).toContain('ar-currency-label');
+		expect(subject).toContain('For tSteelBlue');
 	});
 });

--- a/src/components/OperationOutcomeAnnouncement.tsx
+++ b/src/components/OperationOutcomeAnnouncement.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ArrowUpRight, CircleCheck, TriangleAlert } from 'lucide-react';
 
 import { ArCurrencyText } from './ArCurrencyLabel';
 
@@ -25,13 +26,66 @@ export function OperationOutcome({
 }: React.PropsWithChildren<{ title: string; detail: string }>) {
 	return (
 		<div className="result-outcome">
-			<h3>
+			<h3 className="result-status-heading">
+				<CircleCheck aria-hidden="true" className="result-status-icon ui-icon" />
 				<ArCurrencyText>{title}</ArCurrencyText>
 			</h3>
 			{children}
 			<p>
 				<ArCurrencyText>{detail}</ArCurrencyText>
 			</p>
+		</div>
+	);
+}
+
+export function OperationErrorAlert({ title, message }: { title: string; message: string }) {
+	return (
+		<div className="result-alert" role="alert">
+			<h3 className="result-status-heading">
+				<TriangleAlert aria-hidden="true" className="result-status-icon ui-icon" />
+				<ArCurrencyText>{title}</ArCurrencyText>
+			</h3>
+			<p>
+				<ArCurrencyText>{message}</ArCurrencyText>
+			</p>
+		</div>
+	);
+}
+
+export function OperationExternalLink({ children }: React.PropsWithChildren) {
+	return (
+		<span className="operation-external-link-label">
+			{children}
+			<ArrowUpRight aria-hidden="true" className="ui-icon ui-icon--xs" />
+		</span>
+	);
+}
+
+export function OperationOutcomeSubject({
+	label,
+	title,
+	detail,
+	media,
+}: {
+	label: string;
+	title: string;
+	detail?: string;
+	media?: React.ReactNode;
+}) {
+	return (
+		<div className="operation-outcome-subject">
+			{media ? <div className="operation-outcome-subject-media">{media}</div> : null}
+			<div className="operation-outcome-subject-copy">
+				<span>{label}</span>
+				<strong>
+					<ArCurrencyText>{title}</ArCurrencyText>
+				</strong>
+				{detail ? (
+					<small>
+						<ArCurrencyText>{detail}</ArCurrencyText>
+					</small>
+				) : null}
+			</div>
 		</div>
 	);
 }

--- a/src/helpers/styled.d.ts
+++ b/src/helpers/styled.d.ts
@@ -26,6 +26,7 @@ declare module 'styled-components' {
 		warningText: string;
 		warningSurface: string;
 		warningBorder: string;
+		retryIcon: string;
 		noticeText: string;
 		noticeSurface: string;
 		eventPurple: string;

--- a/src/helpers/theme.ts
+++ b/src/helpers/theme.ts
@@ -43,6 +43,7 @@ const commonGlobal = {
 	gradientBlue: 'rgba(107, 125, 232, 0.28)',
 	gradientBlueSoft: 'rgba(82, 119, 255, 0.22)',
 	ghostGlow: 'rgba(114, 106, 96, 0.08)',
+	retryIcon: '#d6a100',
 } satisfies Partial<DefaultTheme['colors']['global']>;
 
 const lightGlobal: DefaultTheme['colors']['global'] = {

--- a/src/routes/CreateRoute.tsx
+++ b/src/routes/CreateRoute.tsx
@@ -47,9 +47,15 @@ import { AudioArtwork } from 'components/AudioArtwork';
 import { Button } from 'components/Button';
 import { Loading } from 'components/Loading';
 import { MintTransactionReceipt, type MintTransactionReceiptEntry } from 'components/MintTransactionReceipt';
-import { OperationOutcome, OperationOutcomeAnnouncement } from 'components/OperationOutcomeAnnouncement';
+import {
+	OperationErrorAlert,
+	OperationOutcome,
+	OperationOutcomeAnnouncement,
+	OperationOutcomeSubject,
+} from 'components/OperationOutcomeAnnouncement';
 import { SegmentedTabs } from 'components/SegmentedTabs';
 import { TokenArtwork } from 'components/TokenArtwork';
+import { TokenAvatar } from 'components/TokenAvatar';
 import {
 	prepareTransactionDialogHide,
 	TRANSACTION_DIALOG_HIDE_DURATION_MS,
@@ -315,7 +321,21 @@ export function FungibleMintDialog({
 						<OperationOutcome
 							detail={`All ${result.wholeSupply} ${result.ticker} are in your wallet and ready to dispatch.`}
 							title="Token live on Bazar"
-						/>
+						>
+							<OperationOutcomeSubject
+								label="You created"
+								title={`${result.wholeSupply} ${result.ticker}`}
+								detail={tokenName}
+								media={
+									<TokenAvatar
+										className="operation-outcome-token-avatar"
+										image={logoPreview || undefined}
+										loading="eager"
+										ticker={result.ticker}
+									/>
+								}
+							/>
+						</OperationOutcome>
 						<MintTransactionReceipt entries={receiptEntries} />
 						<Button
 							className="with-icon"
@@ -337,10 +357,7 @@ export function FungibleMintDialog({
 				) : null}
 				{dialogPhase === 'error' ? (
 					<div className="result error">
-						<div className="result-alert" role="alert">
-							<h3>Could not create this token</h3>
-							<p>{error}</p>
-						</div>
+						<OperationErrorAlert title="Could not create this token" message={error ?? ''} />
 						<Button
 							data-dialog-initial
 							onClick={() => {

--- a/src/routes/MyAssetsRoute.tsx
+++ b/src/routes/MyAssetsRoute.tsx
@@ -3,7 +3,6 @@ import { RefreshCw, Server } from 'lucide-react';
 
 import {
 	type AssetCandidate,
-	clearCompletedWalletCandidateScan,
 	createAssetCandidateResolver,
 	createWalletCandidateScan,
 	discoverWalletAssetCandidates,
@@ -97,11 +96,6 @@ export default function MyAssetsRoute() {
 	};
 	const refreshAssets = () => {
 		setRetry((value) => value + 1);
-	};
-	const restartDiscovery = () => {
-		if (wallet.address) clearCompletedWalletCandidateScan(window.localStorage, wallet.address);
-		discoverySession.current = undefined;
-		refreshAssets();
 	};
 	React.useEffect(() => {
 		if (!wallet.address || !market.collections.length || market.error) return;
@@ -526,7 +520,7 @@ export default function MyAssetsRoute() {
 			<section className="my-assets-page">
 				<p className="eyebrow">Live wallet inventory</p>
 				<h1>My assets</h1>
-				<ErrorPanel message={market.error} onRetry={market.retry} retryLabel="Retry asset index" />
+				<ErrorPanel message={market.error} onRetry={market.retry} />
 			</section>
 		);
 	}
@@ -592,15 +586,14 @@ export default function MyAssetsRoute() {
 					</span>
 				</div>
 				{!status.error && status.phase === 'done' && status.failures && status.failures < status.total ? (
-					<div className="my-assets-heading-status">
+					<div className="my-assets-heading-status retry-notice">
 						<span role="status">
-							{aggregateFailureMessage} {status.failures.toLocaleString()}{' '}
+							Compute hasn’t completed yet. Please try again. {status.failures.toLocaleString()}{' '}
 							{status.failures === 1 ? 'candidate remains' : 'candidates remain'} unavailable. Resolved
 							assets remain visible.
 						</span>
 						<Button className="with-icon" type="button" onClick={retryUnavailableAssets} size="custom">
-							<RefreshCw className="ui-icon ui-icon--sm" aria-hidden="true" />{' '}
-							{status.rateLimited ? 'Retry later' : 'Retry unavailable'}
+							<RefreshCw className="ui-icon ui-icon--sm" aria-hidden="true" /> Retry
 						</Button>
 					</div>
 				) : null}
@@ -632,16 +625,11 @@ export default function MyAssetsRoute() {
 				</div>
 			) : null}
 			{status.error ? (
-				<div className="inline-error">
-					<span role="alert">{status.error}</span>
-					<div className="inline-error-actions">
-						<Button className="with-icon" onClick={retryDiscovery} size="custom">
-							<RefreshCw className="ui-icon ui-icon--sm" aria-hidden="true" /> Retry from checkpoint
-						</Button>
-						<Button onClick={restartDiscovery} size="custom">
-							Restart discovery
-						</Button>
-					</div>
+				<div className="inline-error retry-notice">
+					<span role="status">Compute hasn’t completed yet. Please try again.</span>
+					<Button className="with-icon" onClick={retryDiscovery} size="custom">
+						<RefreshCw className="ui-icon ui-icon--sm" aria-hidden="true" /> Retry
+					</Button>
 				</div>
 			) : null}
 			{!working || visibleResults.length ? (
@@ -675,13 +663,17 @@ export default function MyAssetsRoute() {
 					</h3>
 					<p>
 						{status.failures
-							? `${aggregateFailureMessage} ${status.failures} of ${status.total} candidates could not be checked. Retry them before treating this as an empty wallet.`
+							? `Compute hasn’t completed yet. Please try again. ${status.failures} of ${status.total} candidates still need to be checked.`
 							: 'Arweave GraphQL discovers candidates and can lag behind new transactions. Newly indexed candidates appear the next time this page opens; live state remains authoritative for every candidate found.'}
 					</p>
 					{status.failures ? (
-						<Button className="with-icon" type="button" onClick={retryUnavailableAssets} size="custom">
-							<RefreshCw className="ui-icon ui-icon--sm" aria-hidden="true" />{' '}
-							{status.rateLimited ? 'Retry later' : 'Retry unavailable assets'}
+						<Button
+							className="with-icon retry-notice-action"
+							type="button"
+							onClick={retryUnavailableAssets}
+							size="custom"
+						>
+							<RefreshCw className="ui-icon ui-icon--sm" aria-hidden="true" /> Retry
 						</Button>
 					) : null}
 				</div>


### PR DESCRIPTION
## Summary

- standardize retryable compute messaging and neutral retry presentation across marketplace flows
- add shared success and error status treatments with clear operation subject summaries
- unify transaction link icons and simplify side-panel receipt styling

## Validation

- `git diff --check`
- `npm test -- --maxWorkers=2` (732 tests passed)
- `npm run build`
- clean dry merge against current `origin/edge`