### PR TITLE
feat: improve transaction continuity and wallet profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ npm run start
 ```
 
 Vite serves the application on `http://127.0.0.1:3000` by default. Development
-uses `https://arweave.net` for compute. Production defaults to Alpha and Charlie
-and fails over between them through AO Wrangler. Select peers in the header, set
+and production both default to Alpha and Charlie for compute and fail over
+between them through AO Wrangler. Select peers in the header, set
 `VITE_COMPUTE_GATEWAY`, or append a comma-separated `node` query parameter:
 
 ```text

--- a/src/api/asset-marketplace.test.ts
+++ b/src/api/asset-marketplace.test.ts
@@ -355,7 +355,7 @@ describe('asset state', () => {
 			},
 		});
 
-		expect(requested).toEqual([`https://arweave.net/${processId}~process@1.0/now`]);
+		expect(requested).toEqual([`${DEFAULT_COMPUTE_GATEWAY}/${processId}~process@1.0/now`]);
 		expect(requestOptions[0].method).toBe('HEAD');
 		expect([...new Headers(requestOptions[0].headers)]).toEqual([]);
 	});
@@ -448,7 +448,7 @@ describe('asset state', () => {
 			},
 		});
 
-		expect(requested).toEqual([`https://arweave.net/${processId}~process@1.0/now`]);
+		expect(requested).toEqual([`${DEFAULT_COMPUTE_GATEWAY}/${processId}~process@1.0/now`]);
 		expect(requestOptions.every((options) => options.cache === undefined)).toBe(true);
 		expect(requestOptions.every((options) => options.method === 'HEAD')).toBe(true);
 		expect(requestOptions.every((options) => [...new Headers(options.headers)].length === 0)).toBe(true);

--- a/src/api/profile.test.ts
+++ b/src/api/profile.test.ts
@@ -64,7 +64,7 @@ describe('Account-0.3 profiles', () => {
 			.mockResolvedValueOnce(
 				Response.json({ handle: 'holder', name: 'Token Holder', bio: 'Collects.', avatar: '' })
 			);
-		const publish = vi.fn(async (_data: string) => 'T'.repeat(43));
+		const publish = vi.fn(async (_data: string | Uint8Array) => 'T'.repeat(43));
 		const client = new ProfileClient({
 			fetch: fetcher as typeof fetch,
 			gateway: 'https://gateway.example',
@@ -90,15 +90,106 @@ describe('Account-0.3 profiles', () => {
 		);
 	});
 
+	it('updates the display name without changing the avatar', async () => {
+		const owner = 'F'.repeat(43);
+		const fetcher = vi
+			.fn()
+			.mockResolvedValueOnce(Response.json({ data: { transactions: { edges: [{ node: { id: profileId } }] } } }))
+			.mockResolvedValueOnce(
+				Response.json({
+					handle: 'old-name',
+					name: 'Full Name',
+					bio: 'Still here.',
+					avatar: `ar://${avatarId}`,
+				})
+			);
+		const publish = vi.fn(async (_data: string | Uint8Array) => 'T'.repeat(43));
+		const client = new ProfileClient({
+			fetch: fetcher as typeof fetch,
+			gateway: 'https://gateway.example',
+			publish,
+		});
+
+		const profile = await client.update(owner, { displayName: 'New name' });
+
+		expect(profile).toMatchObject({
+			handle: 'New name',
+			name: 'Full Name',
+			bio: 'Still here.',
+			avatar: `ar://${avatarId}`,
+		});
+		expect(JSON.parse(String(publish.mock.calls[0][0]))).toMatchObject({
+			handle: 'New name',
+			name: 'Full Name',
+			bio: 'Still here.',
+			avatar: `ar://${avatarId}`,
+		});
+	});
+
+	it('updates the avatar without requiring a display name change', async () => {
+		const owner = 'H'.repeat(43);
+		const fetcher = vi
+			.fn()
+			.mockResolvedValueOnce(Response.json({ data: { transactions: { edges: [{ node: { id: profileId } }] } } }))
+			.mockResolvedValueOnce(
+				Response.json({ handle: 'Keep this name', name: '', bio: 'Still here.', avatar: '' })
+			);
+		const client = new ProfileClient({
+			fetch: fetcher as typeof fetch,
+			gateway: 'https://gateway.example',
+			publish: vi.fn(async () => 'T'.repeat(43)),
+		});
+
+		const profile = await client.update(owner, { avatar: avatarId });
+
+		expect(profile).toMatchObject({
+			handle: 'Keep this name',
+			bio: 'Still here.',
+			avatar: `ar://${avatarId}`,
+		});
+	});
+
+	it('uploads a dropped profile image as a permanent avatar transaction', async () => {
+		const owner = 'G'.repeat(43);
+		const publish = vi.fn(async () => avatarId);
+		const client = new ProfileClient({ publish });
+		const data = new Uint8Array([1, 2, 3]);
+
+		await expect(client.uploadAvatar(owner, data, 'image/webp')).resolves.toBe(avatarId);
+		expect(publish).toHaveBeenCalledWith(
+			data,
+			expect.arrayContaining([
+				{ name: 'Content-Type', value: 'image/webp' },
+				{ name: 'Type', value: 'Profile-Avatar' },
+			]),
+			owner,
+			{}
+		);
+	});
+
+	it('rejects unsupported or oversized profile images before publishing', async () => {
+		const publish = vi.fn(async () => avatarId);
+		const client = new ProfileClient({ publish });
+
+		await expect(client.uploadAvatar(address, new Uint8Array([1]), 'image/svg+xml')).rejects.toThrow(
+			'invalid-profile-avatar-type'
+		);
+		await expect(client.uploadAvatar(address, new Uint8Array(), 'image/png')).rejects.toThrow(
+			'invalid-profile-avatar-size'
+		);
+		expect(publish).not.toHaveBeenCalled();
+	});
+
 	it('rejects malformed wallet and avatar identifiers before network access', async () => {
 		await expect(readAccountProfile('not-an-address')).rejects.toThrow('invalid-profile-address');
 		const client = new ProfileClient({ publish: vi.fn() });
 		await expect(client.setAvatar(address, 'not-an-asset')).rejects.toThrow('invalid-profile-avatar');
+		await expect(client.update(address, {})).rejects.toThrow('empty-profile-update');
 	});
 
 	it('keeps an asset image URL when setting it as the profile picture', async () => {
 		const owner = 'D'.repeat(43);
-		const publish = vi.fn(async (_data: string) => 'T'.repeat(43));
+		const publish = vi.fn(async (_data: string | Uint8Array) => 'T'.repeat(43));
 		const client = new ProfileClient({
 			fetch: vi.fn(async () => Response.json({ data: { transactions: { edges: [] } } })) as typeof fetch,
 			gateway: 'https://gateway.example',
@@ -107,7 +198,7 @@ describe('Account-0.3 profiles', () => {
 
 		await client.setAvatar(owner, `https://arweave.net/${avatarId}`);
 
-		expect(JSON.parse(publish.mock.calls[0][0])).toMatchObject({
+		expect(JSON.parse(String(publish.mock.calls[0][0]))).toMatchObject({
 			avatar: `https://arweave.net/${avatarId}`,
 		});
 	});

--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -1,10 +1,17 @@
 import { createArweaveClient } from 'helpers/arweave';
 import { arweaveClientConfig, arweaveDataUrl, arweaveGatewayFromLocation } from 'helpers/config';
 
-import { type AssetUploadOptions } from './asset-uploader';
+import { type AssetUploadData, type AssetUploadOptions } from './asset-uploader';
 
 const ARWEAVE_ID = /^[A-Za-z0-9_-]{43}$/;
 export const ACCOUNT_PROFILE_PROTOCOL = 'Account-0.3';
+export const PROFILE_AVATAR_CONTENT_TYPES: ReadonlyArray<string> = [
+	'image/gif',
+	'image/jpeg',
+	'image/png',
+	'image/webp',
+];
+export const PROFILE_AVATAR_MAX_BYTES = 10 * 1024 * 1024;
 
 export type AccountProfile = {
 	address: string;
@@ -26,12 +33,17 @@ export type ProfileClientOptions = {
 	fetch?: typeof fetch;
 	arweave?: any;
 	publish?: (
-		data: string,
+		data: AssetUploadData,
 		tags: ReadonlyArray<{ name: string; value: string }>,
 		owner: string,
 		options: AssetUploadOptions
 	) => Promise<string>;
 	gateway?: string;
+};
+
+export type ProfileUpdate = {
+	displayName?: string;
+	avatar?: string;
 };
 
 const cached = new Map<string, AccountProfile | null>();
@@ -179,6 +191,67 @@ export class ProfileClient {
 
 	read(address: string, signal?: AbortSignal) {
 		return readAccountProfile(address, { fetch: this.#fetch, gateway: this.#gateway, signal });
+	}
+
+	async uploadAvatar(
+		owner: string,
+		data: Uint8Array,
+		contentType: string,
+		options: AssetUploadOptions = {}
+	): Promise<string> {
+		assertId(owner, 'invalid-profile-address');
+		if (!PROFILE_AVATAR_CONTENT_TYPES.includes(contentType)) {
+			throw new TypeError('invalid-profile-avatar-type');
+		}
+		if (!data.byteLength || data.byteLength > PROFILE_AVATAR_MAX_BYTES) {
+			throw new TypeError('invalid-profile-avatar-size');
+		}
+		return this.#publish(
+			data,
+			[
+				{ name: 'Content-Type', value: contentType },
+				{ name: 'App-Name', value: 'Bazar' },
+				{ name: 'Type', value: 'Profile-Avatar' },
+			],
+			owner,
+			options
+		);
+	}
+
+	async update(owner: string, update: ProfileUpdate, options: AssetUploadOptions = {}): Promise<AccountProfile> {
+		assertId(owner, 'invalid-profile-address');
+		if (update.displayName === undefined && update.avatar === undefined) {
+			throw new TypeError('empty-profile-update');
+		}
+		const existing = await limitedProfileRead(() =>
+			fetchAccountProfile(owner, {
+				fetch: this.#fetch,
+				gateway: this.#gateway,
+				signal: options.signal,
+			})
+		);
+		const displayName = update.displayName?.trim();
+		const avatar = update.avatar?.trim();
+		const body = {
+			handle: displayName ?? existing?.handle ?? '',
+			name: existing?.name ?? '',
+			bio: existing?.bio ?? '',
+			avatar: avatar === undefined ? existing?.avatar ?? '' : avatar ? normalizeAvatar(avatar) : '',
+		};
+		const transactionId = await this.#publish(
+			JSON.stringify(body),
+			[
+				{ name: 'Content-Type', value: 'application/json' },
+				{ name: 'Protocol-Name', value: ACCOUNT_PROFILE_PROTOCOL },
+				{ name: 'App-Name', value: 'Bazar' },
+				{ name: 'handle', value: body.handle },
+			],
+			owner,
+			options
+		);
+		const profile = { address: owner, transactionId, ...body };
+		cached.set(owner, profile);
+		return profile;
 	}
 
 	async setAvatar(owner: string, avatar: string, options: AssetUploadOptions = {}): Promise<AccountProfile> {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -22,6 +22,7 @@ import {
 	LayoutGrid,
 	Library,
 	LoaderCircle,
+	Plus,
 	RefreshCw,
 	Search,
 	Send,
@@ -3131,7 +3132,7 @@ function Home() {
 	const location = useLocation();
 	const navigate = useNavigate();
 	const { search } = location;
-	const marketPaneRef = React.useRef<HTMLElement>(null);
+	const marketPaneRef = React.useRef<HTMLDivElement>(null);
 	const homeTab = homeTabFromPathname(location.pathname);
 	const [assetType, setAssetType] = React.useState<HomeAssetType>('all');
 	const [assetView, setAssetView] = React.useState<HomeAssetView>('listed');
@@ -4154,8 +4155,8 @@ function Home() {
 		<div className="home-shell">
 			<div className="home-main">
 				<div className="home-content">
-					<div className="home-market-layout">
-						<section className="home-section home-assets" id="market" ref={marketPaneRef}>
+					<div className="home-market-layout" ref={marketPaneRef}>
+						<section className="home-section home-assets" id="market">
 							<h1 className="sr-only">Marketplace</h1>
 							<div className="home-section-heading">
 								<div>
@@ -4877,15 +4878,15 @@ function GatewayControl() {
 	const { pageRefreshing } = React.useContext(MarketContext);
 	const computeNodes = servingNodeOrigins(window.location);
 	const computeCurrent = computeNodes.join(', ');
-	const [computeValue, setComputeValue] = React.useState(computeCurrent);
+	const [computeValues, setComputeValues] = React.useState(() => (computeNodes.length ? computeNodes : ['']));
 	const [open, setOpen] = React.useState(false);
 	const [error, setError] = React.useState('');
 	const detailsRef = React.useRef<HTMLDetailsElement>(null);
 	const triggerRef = React.useRef<HTMLElement>(null);
-	const inputRef = React.useRef<HTMLInputElement>(null);
+	const inputRefs = React.useRef<Array<HTMLInputElement | null>>([]);
 	React.useEffect(() => {
 		if (!open) return;
-		const focusFrame = window.requestAnimationFrame(() => inputRef.current?.focus());
+		const focusFrame = window.requestAnimationFrame(() => inputRefs.current[0]?.focus());
 		const closeOutside = (event: PointerEvent) => {
 			if (event.target instanceof Node && !detailsRef.current?.contains(event.target)) setOpen(false);
 		};
@@ -4905,9 +4906,13 @@ function GatewayControl() {
 	}, [open]);
 	function apply(event: React.FormEvent) {
 		event.preventDefault();
-		const computeOrigins = normalizeServingNodeOrigins(computeValue, window.location.protocol);
+		const parsedPeers = computeValues.map((value) => normalizeServingNodeOrigins(value, window.location.protocol));
+		const computeOrigins =
+			parsedPeers.every((origins) => origins?.length === 1) && parsedPeers.length
+				? [...new Set(parsedPeers.flatMap((origins) => origins ?? []))]
+				: null;
 		if (!computeOrigins) {
-			setError('Enter one or more HTTP or HTTPS HyperBEAM peers, separated by commas.');
+			setError('Enter one valid HTTP or HTTPS HyperBEAM peer in each field.');
 			return;
 		}
 		setError('');
@@ -4961,22 +4966,73 @@ function GatewayControl() {
 				</summary>
 				<div id="gateway-panel">
 					<form onSubmit={apply}>
-						<label>
-							<span>Change AO-Core peers</span>
-							<span className="gateway-peer-description" id="gateway-peer-description">
-								If you would like to use different machines for your computer, enter in below
-							</span>
-							<input
-								aria-describedby={`gateway-peer-description${error ? ' gateway-error' : ''}`}
-								aria-invalid={Boolean(error)}
-								onChange={(event) => {
-									setComputeValue(event.target.value);
+						<fieldset className="gateway-peer-editor">
+							<legend>Change AO-Core peers</legend>
+							<div className="gateway-peer-fields">
+								{computeValues.map((value, index) => (
+									<div className="gateway-peer-row" key={index}>
+										<label className="sr-only" htmlFor={`gateway-peer-${index}`}>
+											AO-Core peer {index + 1}
+										</label>
+										<input
+											aria-describedby={error ? 'gateway-error' : undefined}
+											aria-invalid={Boolean(error)}
+											autoComplete="url"
+											id={`gateway-peer-${index}`}
+											inputMode="url"
+											onChange={(event) => {
+												setComputeValues((current) =>
+													current.map((peer, peerIndex) =>
+														peerIndex === index ? event.target.value : peer
+													)
+												);
+												setError('');
+											}}
+											placeholder="https://peer.example"
+											ref={(node) => {
+												inputRefs.current[index] = node;
+											}}
+											spellCheck={false}
+											value={value}
+										/>
+										{computeValues.length > 1 ? (
+											<Button
+												aria-label={`Remove AO-Core peer ${index + 1}`}
+												className="gateway-peer-remove"
+												onClick={() => {
+													setComputeValues((current) =>
+														current.filter((_, peerIndex) => peerIndex !== index)
+													);
+													setError('');
+													window.requestAnimationFrame(() =>
+														inputRefs.current[Math.max(0, index - 1)]?.focus()
+													);
+												}}
+												size="custom"
+												type="button"
+												variant="ghost"
+											>
+												<X className="ui-icon ui-icon--sm" aria-hidden="true" />
+											</Button>
+										) : null}
+									</div>
+								))}
+							</div>
+							<Button
+								className="gateway-peer-add with-icon"
+								onClick={() => {
+									const nextIndex = computeValues.length;
+									setComputeValues((current) => [...current, '']);
 									setError('');
+									window.requestAnimationFrame(() => inputRefs.current[nextIndex]?.focus());
 								}}
-								ref={inputRef}
-								value={computeValue}
-							/>
-						</label>
+								size="custom"
+								type="button"
+								variant="ghost"
+							>
+								<Plus className="ui-icon ui-icon--sm" aria-hidden="true" /> Add peer
+							</Button>
+						</fieldset>
 						{error ? (
 							<p className="gateway-error" id="gateway-error" role="alert">
 								{error}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -11119,7 +11119,7 @@ function unitPriceWinston(order: SwapOrder, denomination: number) {
 	const scale = 10n ** BigInt(denomination);
 	return (BigInt(order.asking) * scale + BigInt(order.quantity) - 1n) / BigInt(order.quantity);
 }
-function orderPriceLabel(order: SwapOrder, state: AssetState) {
+export function orderPriceLabel(order: SwapOrder, state: AssetState) {
 	return `${winstonToAr(unitPriceWinston(order, state.denomination).toString())} AR${
 		state.totalSupply === '1' && state.denomination === 0 ? '' : ` / ${formatTickerLabel(state.ticker, 'token')}`
 	}`;

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2578,6 +2578,15 @@ function OperationActivityControl() {
 										<span>{activity.status}</span>
 									</span>
 									<span className="operation-activity-progress">
+										{activity.confirmations !== undefined &&
+										activity.confirmationTarget !== undefined ? (
+											<span
+												aria-label={`${activity.confirmations} of ${activity.confirmationTarget} confirmations`}
+												className="operation-activity-confirmations"
+											>
+												{activity.confirmations}/{activity.confirmationTarget}
+											</span>
+										) : null}
 										{activity.phase === 'working' ? (
 											<LoaderCircle
 												className="ui-icon ui-icon--xs operation-activity-loader"

--- a/src/app/FungibleAssetView.test.ts
+++ b/src/app/FungibleAssetView.test.ts
@@ -230,8 +230,11 @@ describe('fungible holders', () => {
 		);
 
 		expect(chart).toContain('aria-label="Test token supply distribution"');
+		expect(chart).toContain('<h2 id="fungible-holder-chart-title">Supply distribution</h2>');
 		expect(chart).toContain('80% of supply; 25% offered for sale');
 		expect(chart).toContain('<pattern');
+		expect(chart).toContain('Selected holder');
+		expect(chart).toContain('Total balance');
 		expect(chart).toContain('Offered for sale');
 	});
 });

--- a/src/app/FungibleAssetView.test.ts
+++ b/src/app/FungibleAssetView.test.ts
@@ -30,8 +30,10 @@ import {
 	FungibleListingComposer,
 	fungibleOfferedPercentage,
 	type FungibleOperationActivity,
+	fungibleOperationActivityProgress,
 	FungibleOperationErrorAlert,
 	fungibleOperationStateError,
+	fungibleOperationWorkingStatus,
 	fungibleOrderActionLabel,
 	fungiblePurchaseActivityAmount,
 	FungiblePurchaseComposer,
@@ -59,6 +61,43 @@ import {
 	visibleOrderbookRows,
 	waitForSettlementBatch,
 } from './FungibleAssetView';
+
+describe('fungible operation activity progress', () => {
+	it('reports the active Arweave confirmation depth for a purchase', () => {
+		expect(
+			fungibleOperationActivityProgress('working', {
+				key: 'register',
+				label: 'Reserve listing',
+				target: 5,
+				confirmations: 2,
+				transaction: { id: 'R'.repeat(43), views: [] },
+			})
+		).toEqual({
+			phase: 'working',
+			status: 'Watching Arweave confirmations…',
+			confirmations: 2,
+			confirmationTarget: 5,
+		});
+	});
+
+	it('keeps the generic working status before a transaction is available', () => {
+		expect(fungibleOperationActivityProgress('working')).toEqual({
+			phase: 'working',
+			status: 'Transaction in progress',
+		});
+	});
+});
+
+describe('fungible operation working status', () => {
+	it('uses one concrete retry message instead of stacking it with purchase lifecycle status', () => {
+		const retryMessage = 'Checking the exact submitted reservation again.';
+		expect(
+			fungibleOperationWorkingStatus('buy', retryMessage, {
+				stage: 'registration-propagating',
+			} as PurchaseState)
+		).toBe(retryMessage);
+	});
+});
 
 const BUYER = 'b'.repeat(43);
 const ORDER_ID = 'o'.repeat(43);

--- a/src/app/FungibleAssetView.tsx
+++ b/src/app/FungibleAssetView.tsx
@@ -98,7 +98,11 @@ import {
 	type MarketplaceOperationFailure,
 	marketplaceOperationFailure,
 } from './marketplace-error';
-import { announceFungibleOperationActivityChange, fungibleOperationActivityId } from './operation-activity';
+import {
+	announceFungibleOperationActivityChange,
+	fungibleOperationActivityId,
+	type FungibleOperationActivitySummary,
+} from './operation-activity';
 import {
 	acquireWalletOperationClaim,
 	assetHasSavedSignedAction,
@@ -604,7 +608,11 @@ export function FungibleAssetView({
 		setOperationActivities((current) => current.map((activity) => ({ ...activity, visible: activity.id === id })));
 	}, []);
 	const publishOperationActivity = React.useCallback(
-		(activity: FungibleOperationActivity, nextPhase: TransactionDialogPhase | null = activity.phase) => {
+		(
+			activity: FungibleOperationActivity,
+			nextPhase: TransactionDialogPhase | null = activity.phase,
+			progress?: Pick<FungibleOperationActivitySummary, 'status' | 'confirmations' | 'confirmationTarget'>
+		) => {
 			const phase = nextPhase ?? 'form';
 			if (phase === 'done') {
 				announceFungibleOperationActivityChange({ type: 'remove', id: activity.id, owner: activity.signer });
@@ -616,7 +624,13 @@ export function FungibleAssetView({
 					owner: activity.signer,
 					operationKind: activity.operation.kind,
 					phase,
-					status: fungibleActivityPhaseStatus(phase),
+					status: progress?.status ?? fungibleActivityPhaseStatus(phase),
+					...(progress?.confirmations !== undefined && progress.confirmationTarget !== undefined
+						? {
+								confirmations: progress.confirmations,
+								confirmationTarget: progress.confirmationTarget,
+						  }
+						: {}),
 					createdAt: activity.createdAt ?? Date.now(),
 				};
 				announceFungibleOperationActivityChange({ type: 'upsert', activity: summary });
@@ -1046,14 +1060,17 @@ export function FungibleAssetView({
 	const recoveryBlocksActions = recoverySuppressed || Boolean(unavailableRecovery) || signedRecoveryLocksAsset;
 	const purchaseBlocksActions = recoveryBlocksActions || Boolean(activePurchaseActivity);
 	const assetBlocksActions = recoveryBlocksActions || Boolean(activeAssetActivity);
-	const handleOperationPhaseChange = React.useCallback(
-		(id: string, nextPhase: TransactionDialogPhase) => {
+	const handleOperationActivityChange = React.useCallback(
+		(
+			id: string,
+			update: Pick<FungibleOperationActivitySummary, 'phase' | 'status' | 'confirmations' | 'confirmationTarget'>
+		) => {
 			const activity = operationActivitiesRef.current.find((candidate) => candidate.id === id);
-			if (activity) publishOperationActivity(activity, nextPhase);
+			if (activity) publishOperationActivity(activity, update.phase, update);
 			setOperationActivities((current) =>
-				current.map((activity) => (activity.id === id ? { ...activity, phase: nextPhase } : activity))
+				current.map((activity) => (activity.id === id ? { ...activity, phase: update.phase } : activity))
 			);
-			if (nextPhase === 'done') void onRefresh();
+			if (update.phase === 'done') void onRefresh();
 		},
 		[onRefresh, publishOperationActivity]
 	);
@@ -1737,7 +1754,7 @@ export function FungibleAssetView({
 							)
 						)
 					}
-					onPhaseChange={(phase) => handleOperationPhaseChange(activity.id, phase)}
+					onActivityChange={(update) => handleOperationActivityChange(activity.id, update)}
 					onRestart={() => {
 						setRecoverySuppressed(false);
 						setOperationActivities((current) =>
@@ -1774,6 +1791,30 @@ function fungibleActivityPhaseStatus(phase: TransactionDialogPhase) {
 		done: 'Complete',
 		error: 'Needs attention',
 	}[phase];
+}
+
+export function fungibleOperationActivityProgress(
+	phase: TransactionDialogPhase,
+	activeStep?: ArweaveSyncStep
+): Pick<FungibleOperationActivitySummary, 'phase' | 'status' | 'confirmations' | 'confirmationTarget'> {
+	if (phase === 'working' && activeStep?.transaction) {
+		const confirmationTarget = Math.max(1, activeStep.target);
+		return {
+			phase,
+			status: 'Watching Arweave confirmations…',
+			confirmations: Math.min(confirmationTarget, quorumConfirmationDepth(activeStep)),
+			confirmationTarget,
+		};
+	}
+	return { phase, status: fungibleActivityPhaseStatus(phase) };
+}
+
+export function fungibleOperationWorkingStatus(
+	operationKind: FungibleOperation['kind'],
+	message: string,
+	purchase?: PurchaseState
+): string {
+	return operationKind === 'buy' ? message || purchaseLifecycleStatus(purchase ?? null) : message;
 }
 
 export type FungiblePurchaseSequenceStep = {
@@ -1859,7 +1900,7 @@ function FungibleOperationDialog({
 	visible,
 	restoreFallback,
 	onHide,
-	onPhaseChange,
+	onActivityChange,
 	onRestart,
 	onClose,
 }: {
@@ -1871,7 +1912,9 @@ function FungibleOperationDialog({
 	visible: boolean;
 	restoreFallback(): HTMLElement | null;
 	onHide(): void;
-	onPhaseChange(phase: TransactionDialogPhase): void;
+	onActivityChange(
+		update: Pick<FungibleOperationActivitySummary, 'phase' | 'status' | 'confirmations' | 'confirmationTarget'>
+	): void;
 	onRestart(): void;
 	onClose(resumeLater?: boolean, refresh?: boolean): void;
 }) {
@@ -1953,8 +1996,8 @@ function FungibleOperationDialog({
 	const attemptRef = React.useRef(new AbortController());
 	const cleanupTimerRef = React.useRef<number | undefined>();
 	const hideTimerRef = React.useRef<number | null>(null);
-	const phaseChangeRef = React.useRef(onPhaseChange);
-	phaseChangeRef.current = onPhaseChange;
+	const activityChangeRef = React.useRef(onActivityChange);
+	activityChangeRef.current = onActivityChange;
 	const resumed = React.useRef(false);
 	const ticker = state.ticker || 'Token';
 	const tickerDisplay = formatTickerLabel(ticker);
@@ -2039,10 +2082,6 @@ function FungibleOperationDialog({
 	React.useEffect(() => {
 		if (visible) setHiding(false);
 	}, [visible]);
-
-	React.useEffect(() => {
-		phaseChangeRef.current(phase);
-	}, [phase]);
 
 	React.useEffect(() => {
 		if (operation.kind !== 'buy' || !matchedOrders.length || operation.resume) {
@@ -2709,6 +2748,7 @@ function FungibleOperationDialog({
 	const visibleOrders = visibleFills.map((fill) => fill.order);
 	const activeOrder = visibleOrders.find((order) => order.orderId === activeOrderId) ?? visibleOrders[0];
 	const activePurchase = activeOrder ? purchaseStates[activeOrder.orderId] : undefined;
+	const workingStatus = fungibleOperationWorkingStatus(operation.kind, message, activePurchase);
 	const observedOrderId = activeOrder?.orderId;
 	React.useEffect(() => {
 		const paymentId = activePurchase?.payment?.id;
@@ -2801,6 +2841,19 @@ function FungibleOperationDialog({
 				},
 		  ]
 		: [];
+	const activeSyncStep =
+		operation.kind === 'buy'
+			? purchaseSteps.find((step) => step.key === activeStep) ?? purchaseSteps[0]
+			: singleSteps[0];
+	const activityProgress = fungibleOperationActivityProgress(phase, activeSyncStep);
+	React.useEffect(() => {
+		activityChangeRef.current(activityProgress);
+	}, [
+		activityProgress.confirmations,
+		activityProgress.confirmationTarget,
+		activityProgress.phase,
+		activityProgress.status,
+	]);
 	const closeOrHide = () => {
 		const action = transactionDialogDismissAction(phase, Boolean(transaction || recoverableBatch));
 		if (action.kind === 'close') {
@@ -3355,10 +3408,7 @@ function FungibleOperationDialog({
 								while this browser data remains available.
 							</p>
 						) : null}
-						{message ? <p className="scheduler-wait">{message}</p> : null}
-						{operation.kind === 'buy' && activePurchase ? (
-							<p className="scheduler-wait">{purchaseLifecycleStatus(activePurchase)}</p>
-						) : null}
+						{workingStatus ? <p className="scheduler-wait">{workingStatus}</p> : null}
 						{operation.kind === 'buy' && visibleOrders.length ? (
 							activeOrder && activePurchase ? (
 								<ArweaveTransactionSync

--- a/src/app/FungibleAssetView.tsx
+++ b/src/app/FungibleAssetView.tsx
@@ -502,10 +502,14 @@ export function FungibleHolderChart({
 			</div>
 			<div className="fungible-holder-chart-detail">
 				<header>
-					<span>Supply distribution</span>
-					<strong id="fungible-holder-chart-title">{holders.length.toLocaleString()} holders</strong>
+					<div>
+						<h2 id="fungible-holder-chart-title">Supply distribution</h2>
+						<p>Select a ring segment to inspect a holder.</p>
+					</div>
+					<span>{holders.length.toLocaleString()} holders</span>
 				</header>
 				<div className="fungible-holder-chart-identity">
+					<span>Selected holder</span>
 					{active.address ? (
 						<WalletAddress address={active.address} label="holder" />
 					) : (
@@ -522,10 +526,16 @@ export function FungibleHolderChart({
 						<dd>{activeOffered}</dd>
 					</div>
 				</dl>
-				<p>
-					{tokenLabel(active.total, state)} total ·{' '}
-					{BigInt(active.listed) > 0n ? tokenLabel(active.listed, state) : 'None'} listed
-				</p>
+				<div className="fungible-holder-chart-balances">
+					<div>
+						<span>Total balance</span>
+						<strong>{tokenLabel(active.total, state)}</strong>
+					</div>
+					<div>
+						<span>Listed</span>
+						<strong>{BigInt(active.listed) > 0n ? tokenLabel(active.listed, state) : 'None'}</strong>
+					</div>
+				</div>
 				<div aria-label="Chart legend" className="fungible-holder-chart-legend">
 					<span>
 						<i aria-hidden="true" /> Held
@@ -1925,7 +1935,11 @@ function FungibleOperationDialog({
 	const [hiding, setHiding] = React.useState(false);
 	const [settlementAnnouncement, setSettlementAnnouncement] = React.useState('');
 	const settlementAnnouncementKeyRef = React.useRef('');
-	const submittedAtRef = React.useRef<number>();
+	const submittedAtRef = React.useRef<number | undefined>(
+		operation.kind === 'buy' && Number.isFinite(operation.resume?.createdAt)
+			? operation.resume?.createdAt
+			: undefined
+	);
 	const purchasesRef = React.useRef<Map<string, SwapPurchase>>(new Map());
 	const networkRef = React.useRef<AssetObserverNetworkLease | null>(null);
 	const claimRef = React.useRef<WalletOperationClaim | null>(null);
@@ -2376,7 +2390,7 @@ function FungibleOperationDialog({
 			collectionId,
 			startingBalance,
 			entries,
-			createdAt: resume?.createdAt ?? Date.now(),
+			createdAt: resume?.createdAt ?? submittedAtRef.current ?? Date.now(),
 			gateway: resume?.gateway ?? currentPurchaseGatewayContext(),
 		};
 		let terminalRecoveryRemoved = false;
@@ -3399,17 +3413,6 @@ function FungibleOperationDialog({
 									: undefined
 							}
 						>
-							{operation.kind === 'buy' && purchaseSteps.length ? (
-								<div className="result-outcome-sync">
-									<ArweaveTransactionSync
-										active={visible}
-										activeStep="pay"
-										startedAt={submittedAtRef.current}
-										steps={purchaseSteps}
-										subject={`${asset.name} · ${tokenLabel(activeOrder?.quantity ?? '0', state)}`}
-									/>
-								</div>
-							) : null}
 							{operation.kind === 'buy' || operation.kind === 'sell' ? (
 								<OperationOutcomeSubject
 									label={operation.kind === 'buy' ? 'You received' : 'You listed'}
@@ -3434,6 +3437,17 @@ function FungibleOperationDialog({
 										/>
 									}
 								/>
+							) : null}
+							{operation.kind === 'buy' && purchaseSteps.length ? (
+								<div className="result-outcome-sync">
+									<ArweaveTransactionSync
+										active={visible}
+										activeStep="pay"
+										startedAt={submittedAtRef.current}
+										steps={purchaseSteps}
+										subject={`${asset.name} · ${tokenLabel(activeOrder?.quantity ?? '0', state)}`}
+									/>
+								</div>
 							) : null}
 						</OperationOutcome>
 						{transaction && operation.kind !== 'transfer' ? (
@@ -4044,7 +4058,7 @@ export function FungiblePurchaseReceiptNavigator({
 					<div>
 						<dt>Seller</dt>
 						<dd>
-							<WalletAddress address={order.creator} label="seller" />
+							<WalletAddress address={order.creator} label="seller" tooltipEscapesOverflow />
 						</dd>
 					</div>
 					<div>

--- a/src/app/my-assets.test.ts
+++ b/src/app/my-assets.test.ts
@@ -7,6 +7,7 @@ import {
 	assetGroupRevealComplete,
 	retainedAssetGroupLimit,
 } from '../helpers/progressive-assets';
+import { listedUniquePrice } from '../routes/MyAssetsRoute';
 
 import {
 	type CandidateSupportFailure,
@@ -195,6 +196,16 @@ describe('My assets retry bookkeeping', () => {
 
 		expect(groups.owned).toEqual([both, owned]);
 		expect(groups.listed).toEqual([both, listed]);
+	});
+
+	it('shows the wallet listing price for a unique asset', () => {
+		const listed = resolved('listed-unique', '0', '1');
+		listed.collection = { ...listed.collection, kind: 'images' };
+		listed.state.totalSupply = '1';
+		listed.state.orders['listed-unique-order'].asking = '2500000000000';
+
+		expect(listedUniquePrice(listed, wallet)).toBe('2.5 AR');
+		expect(listedUniquePrice(listed, 'X'.repeat(43))).toBeUndefined();
 	});
 
 	it('writes retry recovery through the active resumable session', () => {

--- a/src/app/operation-activity.test.ts
+++ b/src/app/operation-activity.test.ts
@@ -323,7 +323,9 @@ function fungibleActivity(overrides: Partial<FungibleOperationActivitySummary> =
 		owner,
 		operationKind: 'buy',
 		phase: 'working',
-		status: 'Transaction in progress',
+		status: 'Watching Arweave confirmations…',
+		confirmations: 2,
+		confirmationTarget: 5,
 		createdAt: 200,
 		...overrides,
 	};

--- a/src/app/operation-activity.ts
+++ b/src/app/operation-activity.ts
@@ -50,6 +50,8 @@ export type FungibleOperationActivitySummary = {
 	operationKind: FungibleOperationKind;
 	phase: OperationActivityPhase;
 	status: string;
+	confirmations?: number;
+	confirmationTarget?: number;
 	createdAt: number;
 };
 
@@ -574,6 +576,17 @@ function parseFungibleActivity(value: unknown): FungibleOperationActivitySummary
 		operationKind,
 		phase: value.phase,
 		status: value.status,
+		...(typeof value.confirmations === 'number' &&
+		Number.isFinite(value.confirmations) &&
+		value.confirmations >= 0 &&
+		typeof value.confirmationTarget === 'number' &&
+		Number.isFinite(value.confirmationTarget) &&
+		value.confirmationTarget > 0
+			? {
+					confirmations: value.confirmations,
+					confirmationTarget: value.confirmationTarget,
+			  }
+			: {}),
 		createdAt: value.createdAt,
 	};
 }

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -9589,10 +9589,6 @@ body input:focus-visible {
 }
 .my-assets-resolution-status {
 	margin: 0 0 30px;
-	padding: 15px 17px;
-	border: 1px solid var(--line);
-	border-radius: 10px;
-	background: var(--panel);
 }
 .my-assets-resolution-status > div:first-child {
 	display: grid;

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1543,15 +1543,55 @@ p {
 	overflow-wrap: anywhere;
 	z-index: 60;
 }
-.gateway label {
-	display: grid;
-	gap: 7px;
+.gateway-peer-editor {
+	min-width: 0;
+	margin: 0;
+	padding: 0;
+	border: 0;
+}
+.gateway-peer-editor legend {
+	margin-bottom: 8px;
+	padding: 0;
 	font-size: var(--type-body);
 }
-.gateway-peer-description {
+.gateway-peer-fields {
+	display: grid;
+	gap: 7px;
+}
+.gateway-peer-row {
+	min-width: 0;
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	align-items: center;
+	gap: 6px;
+}
+.gateway-peer-row input {
+	min-width: 0;
+}
+.gateway .gateway-peer-remove {
+	width: 40px;
+	min-height: 40px;
+	margin-top: 0;
+	padding: 0;
+	display: grid;
+	place-items: center;
+	color: var(--muted);
+}
+.gateway .gateway-peer-remove:hover:not(:disabled) {
+	color: var(--negative-text);
+}
+.gateway .gateway-peer-add {
+	min-height: 32px;
+	margin-top: 7px;
+	padding: 5px 7px;
+	border: 0;
+	background: var(--transparent);
 	color: var(--muted);
 	font-size: var(--type-small);
-	line-height: 1.45;
+}
+.gateway .gateway-peer-add:hover:not(:disabled) {
+	color: var(--ink);
+	background: var(--surface-hover);
 }
 .gateway button {
 	margin-top: 10px;
@@ -8727,7 +8767,7 @@ body input:focus-visible {
 	height: calc(100vh - 122px);
 	height: calc(100dvh - 122px);
 	min-height: 0;
-	overflow: hidden;
+	overflow: visible;
 	position: relative;
 }
 .home-main,
@@ -8736,28 +8776,29 @@ body input:focus-visible {
 }
 .home-content {
 	padding: 0;
-	overflow: hidden;
+	overflow: visible;
 }
 .home-market-layout {
-	width: 100%;
+	width: 100vw;
 	height: 100%;
+	margin-inline: calc(50% - 50vw);
 	display: block;
-}
-.home-section {
-	height: 100%;
-	width: 100%;
-	min-width: 0;
-	max-width: var(--max-view-width);
-	margin: 0 auto;
-	padding-bottom: var(--page-footer-spacing);
 	overflow-y: auto;
 	overscroll-behavior: contain;
 	scroll-padding-bottom: var(--page-footer-spacing);
 	scrollbar-width: none;
 }
-.home-section::-webkit-scrollbar {
+.home-market-layout::-webkit-scrollbar {
 	width: 0;
 	height: 0;
+}
+.home-section {
+	min-height: 100%;
+	width: calc(100% - var(--page-gutter) - var(--page-gutter));
+	min-width: 0;
+	max-width: calc(var(--max-view-width) - var(--page-gutter) - var(--page-gutter));
+	margin: 0 auto;
+	padding-bottom: var(--page-footer-spacing);
 }
 .home-section-heading {
 	min-height: 108px;

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1666,6 +1666,20 @@ p {
 	left: 50%;
 	transform: translateX(-50%);
 }
+.ui-tooltip--floating-layer .ui-tooltip__content {
+	position: fixed;
+	right: auto;
+	bottom: auto;
+	transform: none;
+}
+.ui-tooltip--floating-layer .ui-tooltip__content::before {
+	right: auto;
+	left: calc(var(--ui-tooltip-arrow-left) - 7px);
+}
+.ui-tooltip--floating-layer .ui-tooltip__content::after {
+	right: auto;
+	left: calc(var(--ui-tooltip-arrow-left) - 6px);
+}
 .ui-tooltip:hover .ui-tooltip__content,
 .ui-tooltip:has(> :focus-visible) .ui-tooltip__content,
 .ui-tooltip__content--visible {
@@ -9553,13 +9567,21 @@ body input:focus-visible {
 .operation-side-panel .settlement-receipt-links {
 	padding-top: 0;
 }
-.operation-side-panel .receipt-proof-links a {
-	padding-inline: 0;
-	border: 0;
-	border-radius: 0;
+.operation-side-panel .receipt-proof-links {
+	padding-top: 12px;
+	gap: 12px;
+	border-top: 1px solid var(--line);
 	background: var(--transparent);
 }
+.operation-side-panel .receipt-proof-links a {
+	min-height: 48px;
+	padding: 9px 11px;
+	border: 1px solid var(--line);
+	border-radius: 8px;
+	background: var(--paper);
+}
 .operation-side-panel .receipt-proof-links a:hover {
+	border-color: var(--line-dark);
 	background: var(--surface-hover);
 }
 .operation-side-panel .matched-listings-heading,
@@ -9848,22 +9870,17 @@ body input:focus-visible {
 }
 .fungible-holder-chart-card {
 	margin-bottom: 16px;
-	padding: clamp(16px, 2.2vw, 24px);
+	padding: clamp(18px, 2.4vw, 26px);
 	display: grid;
-	grid-template-columns: minmax(210px, 0.85fr) minmax(240px, 1.15fr);
+	grid-template-columns: minmax(190px, 0.72fr) minmax(280px, 1.28fr);
 	align-items: center;
-	gap: clamp(18px, 3vw, 42px);
-	border: 1px solid var(--line);
-	border-radius: 9px;
-	background: radial-gradient(
-			circle at 24% 48%,
-			color-mix(in srgb, var(--gradient-purple) 38%, var(--transparent)),
-			var(--transparent) 42%
-		),
-		var(--panel);
+	gap: clamp(24px, 3.4vw, 46px);
+	border: 1px solid var(--line-dark);
+	border-radius: 16px;
+	background: var(--paper);
 }
 .fungible-holder-chart-visual {
-	width: min(100%, 286px);
+	width: min(100%, 244px);
 	justify-self: center;
 }
 .fungible-holder-chart-visual svg {
@@ -9871,6 +9888,9 @@ body input:focus-visible {
 	height: auto;
 	display: block;
 	overflow: visible;
+}
+.fungible-holder-chart-visual text {
+	font-family: 'DM Sans', sans-serif;
 }
 .fungible-holder-chart-track,
 .fungible-holder-chart-arc,
@@ -9880,16 +9900,16 @@ body input:focus-visible {
 	transform-origin: 120px 120px;
 }
 .fungible-holder-chart-track {
-	stroke: var(--surface-hover);
-	stroke-width: 42;
+	stroke: var(--surface-subtle);
+	stroke-width: 34;
 }
 .fungible-holder-chart-arc {
-	stroke-width: 42;
+	stroke-width: 34;
 	transition: filter 140ms ease, opacity 140ms ease, stroke-width 140ms ease;
 }
 .fungible-holder-chart-hit {
 	stroke: var(--transparent);
-	stroke-width: 52;
+	stroke-width: 46;
 }
 .fungible-holder-chart-slice {
 	cursor: default;
@@ -9899,7 +9919,7 @@ body input:focus-visible {
 .fungible-holder-chart-slice.is-active .fungible-holder-chart-arc,
 .fungible-holder-chart-slice:focus-visible .fungible-holder-chart-arc {
 	filter: saturate(1.08) drop-shadow(0 2px 3px var(--shadow-soft));
-	stroke-width: 46;
+	stroke-width: 38;
 }
 .fungible-holder-chart-slice:focus-visible .fungible-holder-chart-hit {
 	stroke: color-mix(in srgb, var(--focus-ring) 48%, var(--transparent));
@@ -9907,74 +9927,116 @@ body input:focus-visible {
 }
 .fungible-holder-chart-value {
 	fill: var(--ink);
-	font-size: 1.45rem;
-	font-weight: 400;
+	font-size: 1.65rem;
+	font-weight: 500;
 	font-variant-numeric: tabular-nums;
+	letter-spacing: -0.035em;
 }
 .fungible-holder-chart-label {
 	fill: var(--muted);
-	font-size: 0.68rem;
-	letter-spacing: 0.06em;
+	font-size: var(--type-small);
+	letter-spacing: 0;
 }
 .fungible-holder-chart-detail {
 	min-width: 0;
 	display: grid;
-	gap: 13px;
+	gap: 16px;
 }
 .fungible-holder-chart-detail header {
 	display: flex;
-	align-items: baseline;
+	align-items: flex-start;
 	justify-content: space-between;
 	gap: 16px;
 }
-.fungible-holder-chart-detail header span,
-.fungible-holder-chart-detail dt {
+.fungible-holder-chart-detail header > div {
+	min-width: 0;
+	display: grid;
+	gap: 3px;
+}
+.fungible-holder-chart-detail header h2,
+.fungible-holder-chart-detail header p {
+	margin: 0;
+}
+.fungible-holder-chart-detail header h2 {
+	font: 500 var(--type-body) 'DM Sans', sans-serif;
+}
+.fungible-holder-chart-detail header p,
+.fungible-holder-chart-detail header > span,
+.fungible-holder-chart-detail dt,
+.fungible-holder-chart-identity > span,
+.fungible-holder-chart-balances span {
 	color: var(--muted);
 	font-size: var(--type-small);
 }
-.fungible-holder-chart-detail header span {
-	letter-spacing: 0.08em;
+.fungible-holder-chart-detail header p {
+	line-height: 1.4;
 }
-.fungible-holder-chart-detail header strong {
-	font-size: var(--type-small);
-	font-weight: 400;
+.fungible-holder-chart-detail header > span {
+	flex: 0 0 auto;
+	padding: 5px 8px;
+	border: 1px solid var(--line);
+	border-radius: 999px;
+	background: var(--surface-subtle);
+	white-space: nowrap;
 }
 .fungible-holder-chart-identity {
-	min-height: 34px;
-	display: flex;
-	align-items: center;
+	min-width: 0;
+	display: grid;
+	gap: 3px;
 	font-size: var(--type-body);
 }
 .fungible-holder-chart-identity .wallet-address {
+	width: fit-content;
 	max-width: 100%;
-	padding-left: 0;
+	min-height: 26px;
+	padding: 2px 0;
 	font-size: var(--type-body);
+}
+.fungible-holder-chart-identity > strong {
+	font-weight: 500;
 }
 .fungible-holder-chart-detail dl {
 	margin: 0;
 	display: grid;
 	grid-template-columns: repeat(2, minmax(0, 1fr));
-	gap: 1px;
-	overflow: hidden;
-	border: 1px solid var(--line);
-	border-radius: 7px;
-	background: var(--line);
+	gap: 10px;
 }
 .fungible-holder-chart-detail dl div {
-	padding: 12px;
+	min-width: 0;
+	padding: 13px 14px;
 	display: grid;
-	gap: 4px;
+	gap: 5px;
+	border: 1px solid var(--line);
+	border-radius: 10px;
 	background: var(--surface-subtle);
 }
 .fungible-holder-chart-detail dd {
 	margin: 0;
-	font-size: 1.1rem;
+	font-size: 1.3rem;
+	font-weight: 500;
 	font-variant-numeric: tabular-nums;
+	letter-spacing: -0.025em;
+	line-height: 1.1;
 }
-.fungible-holder-chart-detail > p {
-	margin: 0;
-	color: var(--muted);
-	font-size: var(--type-small);
+.fungible-holder-chart-balances {
+	padding-block: 1px;
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 10px;
+}
+.fungible-holder-chart-balances > div {
+	min-width: 0;
+	display: grid;
+	gap: 2px;
+}
+.fungible-holder-chart-balances strong {
+	min-width: 0;
+	overflow: hidden;
+	font-size: var(--type-body);
+	font-weight: 500;
+	font-variant-numeric: tabular-nums;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 .fungible-holder-chart-legend {
 	display: flex;
@@ -10016,7 +10078,11 @@ body input:focus-visible {
 		grid-template-columns: 1fr;
 	}
 	.fungible-holder-chart-visual {
-		width: min(82vw, 248px);
+		width: min(76vw, 230px);
+	}
+	.fungible-holder-chart-detail dl,
+	.fungible-holder-chart-balances {
+		grid-template-columns: minmax(0, 1fr);
 	}
 	.fungible-orderbook .orderbook-head,
 	.fungible-orderbook .orderbook-row {

--- a/src/components/ArweaveTransactionSync/index.tsx
+++ b/src/components/ArweaveTransactionSync/index.tsx
@@ -136,7 +136,7 @@ export function ArweaveTransactionSync({
 		Boolean(active?.hasError)
 	);
 	const displayedConfirmationDepth = active?.terminal ? confirmationDepth : lifecycle.depth;
-	const terminalTargetReached = Boolean(active?.terminal && target > 0 && confirmationDepth >= target);
+	const terminalDepthBeyondTarget = Boolean(active?.terminal && target > 0 && confirmationDepth > target);
 	const transactionState = transaction?.consensus?.state ?? latestObserverState(transaction?.views ?? []);
 	const progressKey = `${transaction?.id ?? 'none'}:${active?.key ?? 'none'}`;
 	const [estimatedProgress, setEstimatedProgress] = React.useState({ key: progressKey, value: 0 });
@@ -270,11 +270,11 @@ export function ArweaveTransactionSync({
 						</div>
 						<S.Depth
 							aria-label={
-								terminalTargetReached
+								terminalDepthBeyondTarget
 									? `${displayedConfirmationDepth} confirmation${
 											displayedConfirmationDepth === 1 ? '' : 's'
 									  }`
-									: lifecycle.pending
+									: lifecycle.pending && !active.terminal
 									? pendingAfterConfirmation
 									: verificationDelayed
 									? language.transactionSyncVerificationDelayed
@@ -282,9 +282,12 @@ export function ArweaveTransactionSync({
 							}
 							$success={lifecycle.complete}
 						>
-							{terminalTargetReached ? (
-								<strong>{displayedConfirmationDepth}</strong>
-							) : lifecycle.pending ? (
+							{terminalDepthBeyondTarget ? (
+								<>
+									<strong>{displayedConfirmationDepth}</strong>
+									<span> confirmations</span>
+								</>
+							) : lifecycle.pending && !active.terminal ? (
 								<strong>{pendingAfterConfirmation}</strong>
 							) : verificationDelayed ? (
 								<strong>{language.transactionSyncVerificationDelayed}</strong>

--- a/src/components/ArweaveTransactionSync/index.tsx
+++ b/src/components/ArweaveTransactionSync/index.tsx
@@ -75,6 +75,11 @@ type LiveObserverResponseStore = {
 	viewsByTransaction: Map<string, Map<string, ObserverView>>;
 };
 
+type TransactionSyncSessionStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+const TRANSACTION_SYNC_VIEW_CACHE_VERSION = 1;
+const TRANSACTION_SYNC_VIEW_CACHE_PREFIX = 'bazar-transaction-sync-views:v1:';
+
 export type ArweaveSyncTransaction = Pick<PurchaseTransaction, 'id' | 'views'> & {
 	consensus?: PurchaseTransaction['consensus'];
 };
@@ -451,14 +456,23 @@ function localizedRisk(depth: number, language: any): string {
 
 function useLiveObserverResponses(steps: ArweaveSyncStep[]): ArweaveSyncStep[] {
 	const key = steps.map((step) => `${step.key}:${step.transaction?.id ?? ''}`).join('|');
-	const storeRef = React.useRef<LiveObserverResponseStore>({ key, viewsByTransaction: new Map() });
+	const storeRef = React.useRef<LiveObserverResponseStore>();
+	if (!storeRef.current) storeRef.current = createLiveObserverResponseStore(key, steps);
 	const [version, setVersion] = React.useState(0);
 	if (storeRef.current.key !== key) {
-		storeRef.current = { key, viewsByTransaction: new Map() };
+		storeRef.current = createLiveObserverResponseStore(key, steps);
 	}
+	const store = storeRef.current;
 
 	React.useEffect(() => {
 		const transactionIds = new Set(steps.flatMap((step) => (step.transaction ? [step.transaction.id] : [])));
+		for (const step of steps) {
+			if (!step.transaction) continue;
+			const transactionViews = store.viewsByTransaction.get(step.transaction.id) ?? new Map();
+			mergeObserverViewsIntoMap(transactionViews, step.transaction.views);
+			store.viewsByTransaction.set(step.transaction.id, transactionViews);
+			writeCachedObserverViews(browserSessionStorage(), step.transaction.id, [...transactionViews.values()]);
+		}
 		let flushTimer: number | undefined;
 		const scheduleRender = () => {
 			if (flushTimer !== undefined) return;
@@ -470,12 +484,13 @@ function useLiveObserverResponses(steps: ArweaveSyncStep[]): ArweaveSyncStep[] {
 		const handleResponse = (event: Event) => {
 			const detail = (event as CustomEvent<ArweaveObserverResponseDetail>).detail;
 			if (!detail || !transactionIds.has(detail.transactionId)) return;
-			const transactionViews = storeRef.current.viewsByTransaction.get(detail.transactionId) ?? new Map();
+			const transactionViews = store.viewsByTransaction.get(detail.transactionId) ?? new Map();
 			const previous = transactionViews.get(detail.observer.url);
 			const view = observerViewFromResponse(detail, previous);
 			if (!view) return;
 			transactionViews.set(detail.observer.url, view);
-			storeRef.current.viewsByTransaction.set(detail.transactionId, transactionViews);
+			store.viewsByTransaction.set(detail.transactionId, transactionViews);
+			writeCachedObserverViews(browserSessionStorage(), detail.transactionId, [...transactionViews.values()]);
 			scheduleRender();
 		};
 
@@ -490,9 +505,101 @@ function useLiveObserverResponses(steps: ArweaveSyncStep[]): ArweaveSyncStep[] {
 		() =>
 			steps.map((step) => ({
 				...step,
-				transaction: mergeLiveObserverViews(step.transaction, storeRef.current.viewsByTransaction),
+				transaction: mergeLiveObserverViews(step.transaction, store.viewsByTransaction),
 			})),
 		[steps, version]
+	);
+}
+
+function createLiveObserverResponseStore(key: string, steps: ArweaveSyncStep[]): LiveObserverResponseStore {
+	const viewsByTransaction = new Map<string, Map<string, ObserverView>>();
+	const storage = browserSessionStorage();
+	for (const step of steps) {
+		if (!step.transaction) continue;
+		const views = new Map<string, ObserverView>();
+		mergeObserverViewsIntoMap(views, readCachedObserverViews(storage, step.transaction.id));
+		mergeObserverViewsIntoMap(views, step.transaction.views);
+		viewsByTransaction.set(step.transaction.id, views);
+	}
+	return { key, viewsByTransaction };
+}
+
+function mergeObserverViewsIntoMap(target: Map<string, ObserverView>, views: ObserverView[]) {
+	for (const view of views) {
+		const existing = target.get(view.observer.url);
+		if (!existing || observerViewTimestamp(view) >= observerViewTimestamp(existing)) {
+			target.set(view.observer.url, view);
+		}
+	}
+}
+
+function observerViewTimestamp(view: ObserverView) {
+	return Math.max(view.updatedAt, view.lastSeenAt ?? 0);
+}
+
+function browserSessionStorage(): TransactionSyncSessionStorage | undefined {
+	try {
+		return typeof window === 'undefined' ? undefined : window.sessionStorage;
+	} catch {
+		return undefined;
+	}
+}
+
+export function readCachedObserverViews(
+	storage: TransactionSyncSessionStorage | undefined,
+	transactionId: string
+): ObserverView[] {
+	if (!storage) return [];
+	const key = `${TRANSACTION_SYNC_VIEW_CACHE_PREFIX}${transactionId}`;
+	try {
+		const value = JSON.parse(storage.getItem(key) ?? 'null');
+		if (
+			!value ||
+			value.version !== TRANSACTION_SYNC_VIEW_CACHE_VERSION ||
+			value.transactionId !== transactionId ||
+			!Array.isArray(value.views) ||
+			!value.views.every(isCachedObserverView)
+		) {
+			if (value !== null) storage.removeItem(key);
+			return [];
+		}
+		return value.views;
+	} catch {
+		try {
+			storage.removeItem(key);
+		} catch {
+			// A blocked session store should not affect transaction observation.
+		}
+		return [];
+	}
+}
+
+export function writeCachedObserverViews(
+	storage: TransactionSyncSessionStorage | undefined,
+	transactionId: string,
+	views: ObserverView[]
+) {
+	if (!storage || !views.length) return;
+	try {
+		storage.setItem(
+			`${TRANSACTION_SYNC_VIEW_CACHE_PREFIX}${transactionId}`,
+			JSON.stringify({ version: TRANSACTION_SYNC_VIEW_CACHE_VERSION, transactionId, views })
+		);
+	} catch {
+		// Visual continuity is best effort; authoritative recovery uses a separate durable record.
+	}
+}
+
+function isCachedObserverView(value: unknown): value is ObserverView {
+	if (!value || typeof value !== 'object') return false;
+	const view = value as Partial<ObserverView>;
+	return Boolean(
+		view.observer &&
+			typeof view.observer.url === 'string' &&
+			typeof view.observer.label === 'string' &&
+			['unknown', 'not-found', 'pending', 'confirmed', 'gone'].includes(view.state ?? '') &&
+			Number.isFinite(view.confirmations) &&
+			Number.isFinite(view.updatedAt)
 	);
 }
 
@@ -504,7 +611,9 @@ function mergeLiveObserverViews(
 	const merged = new Map(transaction.views.map((view) => [view.observer.url, view]));
 	for (const view of viewsByTransaction.get(transaction.id)?.values() ?? []) {
 		const existing = merged.get(view.observer.url);
-		if (!existing || view.updatedAt >= existing.updatedAt) merged.set(view.observer.url, view);
+		if (!existing || observerViewTimestamp(view) >= observerViewTimestamp(existing)) {
+			merged.set(view.observer.url, view);
+		}
 	}
 	return { ...transaction, views: [...merged.values()] };
 }

--- a/src/components/ArweaveTransactionSync/index.tsx
+++ b/src/components/ArweaveTransactionSync/index.tsx
@@ -136,6 +136,7 @@ export function ArweaveTransactionSync({
 		Boolean(active?.hasError)
 	);
 	const displayedConfirmationDepth = active?.terminal ? confirmationDepth : lifecycle.depth;
+	const terminalTargetReached = Boolean(active?.terminal && target > 0 && confirmationDepth >= target);
 	const transactionState = transaction?.consensus?.state ?? latestObserverState(transaction?.views ?? []);
 	const progressKey = `${transaction?.id ?? 'none'}:${active?.key ?? 'none'}`;
 	const [estimatedProgress, setEstimatedProgress] = React.useState({ key: progressKey, value: 0 });
@@ -269,7 +270,7 @@ export function ArweaveTransactionSync({
 						</div>
 						<S.Depth
 							aria-label={
-								active.terminal
+								terminalTargetReached
 									? `${displayedConfirmationDepth} confirmation${
 											displayedConfirmationDepth === 1 ? '' : 's'
 									  }`
@@ -281,7 +282,7 @@ export function ArweaveTransactionSync({
 							}
 							$success={lifecycle.complete}
 						>
-							{active.terminal ? (
+							{terminalTargetReached ? (
 								<strong>{displayedConfirmationDepth}</strong>
 							) : lifecycle.pending ? (
 								<strong>{pendingAfterConfirmation}</strong>

--- a/src/components/ArweaveTransactionSync/telemetry.test.ts
+++ b/src/components/ArweaveTransactionSync/telemetry.test.ts
@@ -1,7 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
-import { accumulateMiningEstimate, createMiningNetworkTracker, recordMiningSample } from './useArweaveMiningTelemetry';
-import { type ArweaveSyncStep, protocolActivityDetail, transactionSyncSessionKey } from '.';
+import {
+	accumulateMiningEstimate,
+	createMiningNetworkTracker,
+	miningTelemetrySession,
+	recordMiningSample,
+	writeMiningTelemetrySession,
+} from './useArweaveMiningTelemetry';
+import {
+	type ArweaveSyncStep,
+	protocolActivityDetail,
+	readCachedObserverViews,
+	transactionSyncSessionKey,
+	writeCachedObserverViews,
+} from '.';
 
 const language = {
 	transactionSyncProtocolActivity:
@@ -24,6 +36,48 @@ function step(key: string, id?: string): ArweaveSyncStep {
 }
 
 describe('transaction synchronization telemetry', () => {
+	it('restores the latest observer view for a transaction after a page reload', () => {
+		const values = new Map<string, string>();
+		const storage = {
+			getItem: (key: string) => values.get(key) ?? null,
+			setItem: (key: string, value: string) => values.set(key, value),
+			removeItem: (key: string) => values.delete(key),
+		};
+		const transactionId = 'R'.repeat(43);
+		const views = [
+			{
+				observer: {
+					url: 'https://observer.example',
+					label: 'observer.example',
+					source: 'peer' as const,
+					failures: 0,
+				},
+				state: 'confirmed' as const,
+				confirmations: 5,
+				updatedAt: 10,
+				lastSeenAt: 11,
+				changedAt: 10,
+			},
+		];
+
+		writeCachedObserverViews(storage, transactionId, views);
+		expect(readCachedObserverViews(storage, transactionId)).toEqual(views);
+	});
+
+	it('ignores and clears malformed observer view cache entries', () => {
+		const transactionId = 'R'.repeat(43);
+		const key = `bazar-transaction-sync-views:v1:${transactionId}`;
+		const values = new Map([[key, JSON.stringify({ version: 1, transactionId, views: [{ state: 'confirmed' }] })]]);
+		const storage = {
+			getItem: (storageKey: string) => values.get(storageKey) ?? null,
+			setItem: (storageKey: string, value: string) => values.set(storageKey, value),
+			removeItem: (storageKey: string) => values.delete(storageKey),
+		};
+
+		expect(readCachedObserverViews(storage, transactionId)).toEqual([]);
+		expect(values.has(key)).toBe(false);
+	});
+
 	it('keeps one cumulative session when a later transaction joins the sequence', () => {
 		const registration = 'R'.repeat(43);
 		expect(transactionSyncSessionKey([step('register', registration), step('pay')])).toBe(registration);
@@ -43,6 +97,46 @@ describe('transaction synchronization telemetry', () => {
 		recordMiningSample(tracker, 6_000, 20, 200);
 		expect(tracker.candidatesSinceStart).toBe(50);
 		expect(tracker.bytesReadSinceStart).toBe(500);
+	});
+
+	it('restores cumulative mining telemetry and accepted proofs after a page reload', () => {
+		const values = new Map<string, string>();
+		const storage = {
+			getItem: (key: string) => values.get(key) ?? null,
+			setItem: (key: string, value: string) => values.set(key, value),
+			removeItem: (key: string) => values.delete(key),
+		};
+		const tracker = createMiningNetworkTracker(1_000);
+		recordMiningSample(tracker, 4_000, 10, 100);
+		const telemetry = {
+			available: true,
+			checked: true,
+			candidateRate: 10,
+			averageCandidateRate: 10,
+			diskReadRate: 100,
+			averageDiskReadRate: 100,
+			candidatesSinceStart: 30,
+			bytesReadSinceStart: 300,
+			sourceLabel: 'arweave.example',
+			acceptedProofs: [
+				{
+					key: '10:block',
+					height: 10,
+					blockId: 'block',
+					proofCount: 1,
+					recallBytes: [],
+					recallSamples: [],
+					transactionCount: 0,
+					observedAt: 3_000,
+				},
+			],
+		};
+
+		writeMiningTelemetrySession(storage, 'https://arweave.example', 'session', 1_000, telemetry, tracker);
+		expect(miningTelemetrySession(storage, 'https://arweave.example', 'session', 1_000)).toEqual({
+			telemetry,
+			tracker,
+		});
 	});
 
 	it('describes observer depth without implying that network quorum advanced', () => {

--- a/src/components/ArweaveTransactionSync/useArweaveMiningTelemetry.ts
+++ b/src/components/ArweaveTransactionSync/useArweaveMiningTelemetry.ts
@@ -35,19 +35,53 @@ type MiningNetworkTracker = {
 	bytesReadSinceStart: number;
 };
 
+type MiningTelemetryStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+type MiningTelemetrySession = {
+	telemetry: ArweaveMiningTelemetry;
+	tracker: MiningNetworkTracker;
+};
+
+const MINING_TELEMETRY_CACHE_VERSION = 1;
+const MINING_TELEMETRY_CACHE_PREFIX = 'bazar-transaction-sync-mining:v1:';
+
 export function useArweaveMiningTelemetry(
 	enabled: boolean,
 	sessionKey: string,
 	sessionStartedAt: number
 ): ArweaveMiningTelemetry {
 	const blockOrigin = import.meta.env.VITE_ARWEAVE_BLOCK_SOURCE_URL || arweaveGatewayFromLocation();
-	const [telemetry, setTelemetry] = React.useState<ArweaveMiningTelemetry>(() => initialTelemetry(blockOrigin));
-	const trackerRef = React.useRef<MiningNetworkTracker>(createMiningNetworkTracker(sessionStartedAt));
+	const initialSessionRef = React.useRef<MiningTelemetrySession>();
+	if (!initialSessionRef.current) {
+		initialSessionRef.current = miningTelemetrySession(
+			browserSessionStorage(),
+			blockOrigin,
+			sessionKey,
+			sessionStartedAt
+		);
+	}
+	const [telemetry, setTelemetry] = React.useState<ArweaveMiningTelemetry>(initialSessionRef.current.telemetry);
+	const trackerRef = React.useRef<MiningNetworkTracker>(initialSessionRef.current.tracker);
+	const telemetryRef = React.useRef(telemetry);
+	telemetryRef.current = telemetry;
 
 	React.useEffect(() => {
-		trackerRef.current = createMiningNetworkTracker(sessionStartedAt);
-		setTelemetry(initialTelemetry(blockOrigin));
+		const restored = miningTelemetrySession(browserSessionStorage(), blockOrigin, sessionKey, sessionStartedAt);
+		trackerRef.current = restored.tracker;
+		telemetryRef.current = restored.telemetry;
+		setTelemetry(restored.telemetry);
 	}, [blockOrigin, sessionKey, sessionStartedAt]);
+
+	React.useEffect(() => {
+		writeMiningTelemetrySession(
+			browserSessionStorage(),
+			blockOrigin,
+			sessionKey,
+			sessionStartedAt,
+			telemetryRef.current,
+			trackerRef.current
+		);
+	}, [blockOrigin, sessionKey, sessionStartedAt, telemetry]);
 
 	React.useEffect(() => {
 		if (!enabled || !blockOrigin) return undefined;
@@ -60,28 +94,43 @@ export function useArweaveMiningTelemetry(
 				const now = Date.now();
 				const tracker = trackerRef.current;
 				recordMiningSample(tracker, now, proof.estimatedCandidateRate, proof.estimatedDiskReadRate);
-				setTelemetry((current) =>
-					telemetryFromTracker(current, tracker, insertAcceptedProof(current.acceptedProofs, proof), true)
-				);
+				setTelemetry((current) => {
+					const next = telemetryFromTracker(
+						current,
+						tracker,
+						insertAcceptedProof(current.acceptedProofs, proof),
+						true
+					);
+					telemetryRef.current = next;
+					return next;
+				});
 
 				if (!enrichingProofs.has(proof.key)) {
 					enrichingProofs.add(proof.key);
 					void enrichAcceptedBlockContent(proof, controller.signal)
 						.then((contentEntry) => {
 							if (controller.signal.aborted) return contentEntry;
-							setTelemetry((current) => ({
-								...current,
-								acceptedProofs: upsertAcceptedProof(current.acceptedProofs, contentEntry),
-							}));
+							setTelemetry((current) => {
+								const next = {
+									...current,
+									acceptedProofs: upsertAcceptedProof(current.acceptedProofs, contentEntry),
+								};
+								telemetryRef.current = next;
+								return next;
+							});
 							return contentEntry;
 						})
 						.then((contentEntry) => enrichAcceptedBlockProof(blockOrigin, contentEntry, controller.signal))
 						.then((currentEntry) => {
 							if (controller.signal.aborted) return;
-							setTelemetry((current) => ({
-								...current,
-								acceptedProofs: upsertAcceptedProof(current.acceptedProofs, currentEntry),
-							}));
+							setTelemetry((current) => {
+								const next = {
+									...current,
+									acceptedProofs: upsertAcceptedProof(current.acceptedProofs, currentEntry),
+								};
+								telemetryRef.current = next;
+								return next;
+							});
 						})
 						.catch(() => {
 							// Keep the block annotation visible and retry its recall metadata on the next poll.
@@ -92,14 +141,16 @@ export function useArweaveMiningTelemetry(
 				if (!controller.signal.aborted) {
 					const tracker = trackerRef.current;
 					accumulateMiningEstimate(tracker, Date.now());
-					setTelemetry((current) =>
-						telemetryFromTracker(
+					setTelemetry((current) => {
+						const next = telemetryFromTracker(
 							current,
 							tracker,
 							current.acceptedProofs,
 							current.acceptedProofs.length > 0
-						)
-					);
+						);
+						telemetryRef.current = next;
+						return next;
+					});
 				}
 			}
 			if (!controller.signal.aborted) timer = window.setTimeout(poll, 5_000);
@@ -108,10 +159,141 @@ export function useArweaveMiningTelemetry(
 		return () => {
 			controller.abort();
 			if (timer !== undefined) window.clearTimeout(timer);
+			const tracker = trackerRef.current;
+			accumulateMiningEstimate(tracker, Date.now());
+			const current = telemetryRef.current;
+			const next = telemetryFromTracker(current, tracker, current.acceptedProofs, current.available);
+			telemetryRef.current = next;
+			writeMiningTelemetrySession(
+				browserSessionStorage(),
+				blockOrigin,
+				sessionKey,
+				sessionStartedAt,
+				next,
+				tracker
+			);
 		};
 	}, [blockOrigin, enabled, sessionKey, sessionStartedAt]);
 
 	return telemetry;
+}
+
+function browserSessionStorage(): MiningTelemetryStorage | undefined {
+	try {
+		return typeof window === 'undefined' ? undefined : window.sessionStorage;
+	} catch {
+		return undefined;
+	}
+}
+
+export function miningTelemetrySession(
+	storage: MiningTelemetryStorage | undefined,
+	blockOrigin: string,
+	sessionKey: string,
+	sessionStartedAt: number
+): MiningTelemetrySession {
+	const fresh = {
+		telemetry: initialTelemetry(blockOrigin),
+		tracker: createMiningNetworkTracker(sessionStartedAt),
+	};
+	if (!storage) return fresh;
+	const key = `${MINING_TELEMETRY_CACHE_PREFIX}${sessionKey}`;
+	try {
+		const value = JSON.parse(storage.getItem(key) ?? 'null');
+		if (
+			!value ||
+			value.version !== MINING_TELEMETRY_CACHE_VERSION ||
+			value.blockOrigin !== blockOrigin ||
+			value.sessionKey !== sessionKey ||
+			value.sessionStartedAt !== sessionStartedAt ||
+			!isMiningTelemetry(value.telemetry) ||
+			!isMiningNetworkTracker(value.tracker)
+		) {
+			if (value !== null) storage.removeItem(key);
+			return fresh;
+		}
+		return { telemetry: value.telemetry, tracker: value.tracker };
+	} catch {
+		try {
+			storage.removeItem(key);
+		} catch {
+			// A blocked session store should not affect mining telemetry.
+		}
+		return fresh;
+	}
+}
+
+export function writeMiningTelemetrySession(
+	storage: MiningTelemetryStorage | undefined,
+	blockOrigin: string,
+	sessionKey: string,
+	sessionStartedAt: number,
+	telemetry: ArweaveMiningTelemetry,
+	tracker: MiningNetworkTracker
+) {
+	if (!storage) return;
+	try {
+		storage.setItem(
+			`${MINING_TELEMETRY_CACHE_PREFIX}${sessionKey}`,
+			JSON.stringify({
+				version: MINING_TELEMETRY_CACHE_VERSION,
+				blockOrigin,
+				sessionKey,
+				sessionStartedAt,
+				telemetry,
+				tracker,
+			})
+		);
+	} catch {
+		// The transaction remains recoverable even when optional visual telemetry cannot be cached.
+	}
+}
+
+function isMiningTelemetry(value: unknown): value is ArweaveMiningTelemetry {
+	if (!value || typeof value !== 'object') return false;
+	const telemetry = value as Partial<ArweaveMiningTelemetry>;
+	return Boolean(
+		typeof telemetry.available === 'boolean' &&
+			typeof telemetry.checked === 'boolean' &&
+			isOptionalFiniteNumber(telemetry.candidateRate) &&
+			isOptionalFiniteNumber(telemetry.averageCandidateRate) &&
+			isOptionalFiniteNumber(telemetry.diskReadRate) &&
+			isOptionalFiniteNumber(telemetry.averageDiskReadRate) &&
+			isFiniteNonNegative(telemetry.candidatesSinceStart) &&
+			isFiniteNonNegative(telemetry.bytesReadSinceStart) &&
+			typeof telemetry.sourceLabel === 'string' &&
+			Array.isArray(telemetry.acceptedProofs) &&
+			telemetry.acceptedProofs.every(
+				(proof) =>
+					proof &&
+					typeof proof.key === 'string' &&
+					isFiniteNonNegative(proof.height) &&
+					isFiniteNonNegative(proof.observedAt)
+			)
+	);
+}
+
+function isMiningNetworkTracker(value: unknown): value is MiningNetworkTracker {
+	if (!value || typeof value !== 'object') return false;
+	const tracker = value as Partial<MiningNetworkTracker>;
+	return Boolean(
+		isFiniteNonNegative(tracker.lastAt) &&
+			isOptionalFiniteNumber(tracker.candidateRate) &&
+			isOptionalFiniteNumber(tracker.diskReadRate) &&
+			isFiniteNonNegative(tracker.weightedCandidateTotal) &&
+			isFiniteNonNegative(tracker.weightedDiskTotal) &&
+			isFiniteNonNegative(tracker.duration) &&
+			isFiniteNonNegative(tracker.candidatesSinceStart) &&
+			isFiniteNonNegative(tracker.bytesReadSinceStart)
+	);
+}
+
+function isOptionalFiniteNumber(value: unknown) {
+	return value === undefined || Number.isFinite(value);
+}
+
+function isFiniteNonNegative(value: unknown) {
+	return typeof value === 'number' && Number.isFinite(value) && value >= 0;
 }
 
 export function recordMiningSample(

--- a/src/components/ArweaveTransactionSync/verification-delay.test.tsx
+++ b/src/components/ArweaveTransactionSync/verification-delay.test.tsx
@@ -55,6 +55,31 @@ function renderLoader(answering: number, eligible: number, views: ObserverView[]
 }
 
 describe('observer verification delay', () => {
+	it('renders the required denominator while a terminal transaction is still confirming', () => {
+		const markup = renderToStaticMarkup(
+			<ThemeProvider theme={theme}>
+				<LanguageProvider>
+					<ArweaveTransactionSync
+						subject="Asset"
+						steps={[
+							{
+								key: 'list',
+								label: 'List for sale',
+								target: 5,
+								terminal: true,
+								confirmations: 1,
+								transaction: { id: 'L'.repeat(43), views: [] },
+							},
+						]}
+					/>
+				</LanguageProvider>
+			</ThemeProvider>
+		);
+
+		expect(markup).toContain('aria-label="1 of 5"');
+		expect(markup).toContain('>1</strong><span> / 5</span>');
+	});
+
 	it('renders terminal confirmation depth without a denominator or cap', () => {
 		const markup = renderToStaticMarkup(
 			<ThemeProvider theme={theme}>

--- a/src/components/ArweaveTransactionSync/verification-delay.test.tsx
+++ b/src/components/ArweaveTransactionSync/verification-delay.test.tsx
@@ -103,8 +103,35 @@ describe('observer verification delay', () => {
 		);
 
 		expect(markup).toContain('aria-label="7 confirmations"');
-		expect(markup).toContain('>7</strong>');
+		expect(markup).toContain('>7</strong><span> confirmations</span>');
 		expect(markup).not.toContain(' / 1');
+		expect(markup).toContain('Checking receipt');
+	});
+
+	it('renders the completed payment target instead of a bare one while checking the receipt', () => {
+		const markup = renderToStaticMarkup(
+			<ThemeProvider theme={theme}>
+				<LanguageProvider>
+					<ArweaveTransactionSync
+						subject="Asset"
+						pendingAfterConfirmation="Checking receipt"
+						steps={[
+							{
+								key: 'pay',
+								label: 'Pay seller',
+								target: 1,
+								terminal: true,
+								confirmations: 1,
+								transaction: { id: 'P'.repeat(43), views: [] },
+							},
+						]}
+					/>
+				</LanguageProvider>
+			</ThemeProvider>
+		);
+
+		expect(markup).toContain('aria-label="1 of 1"');
+		expect(markup).toContain('>1</strong><span> / 1</span>');
 		expect(markup).toContain('Checking receipt');
 	});
 

--- a/src/components/Tooltip.test.tsx
+++ b/src/components/Tooltip.test.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
-import { Tooltip, TooltipSurface } from './Tooltip';
+import { floatingTooltipPosition, Tooltip, TooltipSurface } from './Tooltip';
 
 describe('Tooltip', () => {
 	it('links reusable trigger content to a bottom tooltip', () => {
@@ -60,5 +60,15 @@ describe('Tooltip', () => {
 
 		expect(markup).toContain('ui-tooltip--align-center');
 		expect(markup).toContain('--ui-tooltip-delay:1000ms');
+	});
+
+	it('keeps floating tooltips within the viewport and flips them away from an edge', () => {
+		expect(
+			floatingTooltipPosition(
+				{ bottom: 28, height: 20, left: 4, right: 104, top: 8, width: 100 },
+				{ height: 44, width: 240 },
+				{ align: 'end', placement: 'top', viewportHeight: 320, viewportWidth: 280 }
+			)
+		).toEqual({ arrowLeft: 46, left: 8, placement: 'bottom', top: 37 });
 	});
 });

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
+
+const useBrowserLayoutEffect = typeof document === 'undefined' ? React.useEffect : React.useLayoutEffect;
 
 export type TooltipPlacement = 'bottom' | 'top';
 export type TooltipAlignment = 'center' | 'end' | 'start';
@@ -11,6 +14,7 @@ type TooltipProps = {
 	contentClassName?: string;
 	delayMs?: number;
 	disabled?: boolean;
+	escapeOverflow?: boolean;
 	placement?: TooltipPlacement;
 };
 
@@ -44,12 +48,104 @@ export function Tooltip({
 	contentClassName,
 	delayMs = 0,
 	disabled = false,
+	escapeOverflow = false,
 	placement = 'bottom',
 }: TooltipProps) {
 	const tooltipId = React.useId();
+	const anchorRef = React.useRef<HTMLSpanElement>(null);
+	const surfaceRef = React.useRef<HTMLSpanElement>(null);
+	const hoverTimerRef = React.useRef<number | null>(null);
+	const [floatingVisible, setFloatingVisible] = React.useState(false);
+	const [floatingPosition, setFloatingPosition] = React.useState<{
+		arrowLeft: number;
+		left: number;
+		placement: TooltipPlacement;
+		top: number;
+	} | null>(null);
 	const tooltipStyle = {
 		'--ui-tooltip-delay': `${Math.max(0, delayMs)}ms`,
 	} as React.CSSProperties;
+	const clearHoverTimer = React.useCallback(() => {
+		if (hoverTimerRef.current === null) return;
+		window.clearTimeout(hoverTimerRef.current);
+		hoverTimerRef.current = null;
+	}, []);
+	const showFloatingTooltip = React.useCallback(
+		(immediate = false) => {
+			if (!escapeOverflow || disabled) return;
+			clearHoverTimer();
+			if (immediate || delayMs <= 0) {
+				setFloatingVisible(true);
+				return;
+			}
+			hoverTimerRef.current = window.setTimeout(() => setFloatingVisible(true), delayMs);
+		},
+		[clearHoverTimer, delayMs, disabled, escapeOverflow]
+	);
+	const hideFloatingTooltip = React.useCallback(() => {
+		clearHoverTimer();
+		setFloatingVisible(false);
+		setFloatingPosition(null);
+	}, [clearHoverTimer]);
+
+	useBrowserLayoutEffect(() => {
+		if (!escapeOverflow || !floatingVisible) return;
+		const updatePosition = () => {
+			const anchor = anchorRef.current;
+			const surface = surfaceRef.current;
+			if (!anchor || !surface) return;
+			setFloatingPosition(
+				floatingTooltipPosition(anchor.getBoundingClientRect(), surface.getBoundingClientRect(), {
+					align,
+					placement,
+					viewportHeight: window.innerHeight,
+					viewportWidth: window.innerWidth,
+				})
+			);
+		};
+		updatePosition();
+		window.addEventListener('resize', updatePosition);
+		window.addEventListener('scroll', updatePosition, true);
+		return () => {
+			window.removeEventListener('resize', updatePosition);
+			window.removeEventListener('scroll', updatePosition, true);
+		};
+	}, [align, escapeOverflow, floatingVisible, placement]);
+
+	React.useEffect(() => clearHoverTimer, [clearHoverTimer]);
+
+	const anchoredSurface = (
+		<TooltipSurface className={contentClassName} id={tooltipId}>
+			{content}
+		</TooltipSurface>
+	);
+	const floatingSurface =
+		escapeOverflow && floatingVisible && typeof document !== 'undefined'
+			? createPortal(
+					<span
+						className={`ui-tooltip ui-tooltip--floating-layer ui-tooltip--${
+							floatingPosition?.placement ?? placement
+						} ui-tooltip--align-${align}`}
+					>
+						<TooltipSurface
+							className={contentClassName}
+							id={tooltipId}
+							ref={surfaceRef}
+							style={
+								{
+									'--ui-tooltip-arrow-left': `${floatingPosition?.arrowLeft ?? 18}px`,
+									left: floatingPosition?.left ?? -9999,
+									top: floatingPosition?.top ?? -9999,
+								} as React.CSSProperties
+							}
+							visible={floatingPosition !== null}
+						>
+							{content}
+						</TooltipSurface>
+					</span>,
+					document.body
+			  )
+			: null;
 
 	return (
 		<span
@@ -62,12 +158,66 @@ export function Tooltip({
 			]
 				.filter(Boolean)
 				.join(' ')}
+			onBlurCapture={(event) => {
+				if (!event.currentTarget.contains(event.relatedTarget as Node | null)) hideFloatingTooltip();
+			}}
+			onFocusCapture={() => showFloatingTooltip(true)}
+			onMouseEnter={() => showFloatingTooltip()}
+			onMouseLeave={hideFloatingTooltip}
+			ref={anchorRef}
 			style={tooltipStyle}
 		>
 			{children(tooltipId)}
-			<TooltipSurface className={contentClassName} id={tooltipId}>
-				{content}
-			</TooltipSurface>
+			{escapeOverflow && floatingVisible ? null : anchoredSurface}
+			{floatingSurface}
 		</span>
 	);
+}
+
+export function floatingTooltipPosition(
+	anchor: Pick<DOMRect, 'bottom' | 'height' | 'left' | 'right' | 'top' | 'width'>,
+	surface: Pick<DOMRect, 'height' | 'width'>,
+	options: {
+		align: TooltipAlignment;
+		placement: TooltipPlacement;
+		viewportHeight: number;
+		viewportWidth: number;
+	}
+) {
+	const margin = 8;
+	const gap = 9;
+	const idealLeft =
+		options.align === 'start'
+			? anchor.left
+			: options.align === 'center'
+			? anchor.left + (anchor.width - surface.width) / 2
+			: anchor.right - surface.width;
+	const left = Math.min(
+		Math.max(margin, idealLeft),
+		Math.max(margin, options.viewportWidth - surface.width - margin)
+	);
+	const anchorCenter = anchor.left + anchor.width / 2;
+	const arrowLeft = Math.min(Math.max(14, anchorCenter - left), Math.max(14, surface.width - 14));
+	const topPosition = anchor.top - surface.height - gap;
+	const bottomPosition = anchor.bottom + gap;
+	let resolvedPlacement = options.placement;
+	if (
+		options.placement === 'top' &&
+		topPosition < margin &&
+		bottomPosition + surface.height <= options.viewportHeight
+	) {
+		resolvedPlacement = 'bottom';
+	} else if (
+		options.placement === 'bottom' &&
+		bottomPosition + surface.height > options.viewportHeight - margin &&
+		topPosition >= margin
+	) {
+		resolvedPlacement = 'top';
+	}
+	const idealTop = resolvedPlacement === 'top' ? topPosition : bottomPosition;
+	const top = Math.min(
+		Math.max(margin, idealTop),
+		Math.max(margin, options.viewportHeight - surface.height - margin)
+	);
+	return { arrowLeft, left, placement: resolvedPlacement, top };
 }

--- a/src/components/WalletAddress.tsx
+++ b/src/components/WalletAddress.tsx
@@ -9,11 +9,13 @@ export function WalletAddress({
 	className = '',
 	full = false,
 	label = 'wallet',
+	tooltipEscapesOverflow = false,
 }: {
 	address: string;
 	className?: string;
 	full?: boolean;
 	label?: string;
+	tooltipEscapesOverflow?: boolean;
 }) {
 	const [copyState, setCopyState] = React.useState<'idle' | 'copied' | 'failed'>('idle');
 	const resetTimer = React.useRef<number | null>(null);
@@ -38,7 +40,12 @@ export function WalletAddress({
 	const shortened = address.length > 14 ? `${address.slice(0, 6)}…${address.slice(-5)}` : address;
 	return (
 		<>
-			<Tooltip className="wallet-address-tooltip" content={address} placement="top">
+			<Tooltip
+				className="wallet-address-tooltip"
+				content={address}
+				escapeOverflow={tooltipEscapesOverflow}
+				placement="top"
+			>
 				{(tooltipId) => (
 					<Button
 						aria-describedby={tooltipId}

--- a/src/helpers/config.test.ts
+++ b/src/helpers/config.test.ts
@@ -29,9 +29,10 @@ function location(overrides: Partial<Location> = {}): Location {
 }
 
 describe('Arweave gateway routing', () => {
-	it('keeps local development off the production compute gateway by default', () => {
-		expect(computeGatewayForEnvironment(true)).toBe(DEFAULT_ARWEAVE_GATEWAY);
+	it('uses the production compute peers during local development too', () => {
+		expect(computeGatewayForEnvironment(true)).toBe(PRODUCTION_COMPUTE_GATEWAY);
 		expect(computeGatewayForEnvironment(false)).toBe(PRODUCTION_COMPUTE_GATEWAY);
+		expect(computeGatewaysForEnvironment(true)).toEqual(PRODUCTION_COMPUTE_GATEWAYS);
 		expect(computeGatewaysForEnvironment(false)).toEqual(PRODUCTION_COMPUTE_GATEWAYS);
 		expect(computeGatewayForEnvironment(true, 'http://127.0.0.1:3101/path')).toBe('http://127.0.0.1:3101');
 	});

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -22,13 +22,13 @@ export function normalizeComputeGateways(value: string, defaultProtocol = 'https
 	return origins.length && origins.every(Boolean) ? [...new Set(origins as string[])] : null;
 }
 
-export function computeGatewaysForEnvironment(development: boolean, configured = configuredComputeGateway): string[] {
+export function computeGatewaysForEnvironment(_development: boolean, configured = configuredComputeGateway): string[] {
 	if (configured) {
 		const parsed = normalizeComputeGateways(configured);
 		if (!parsed) throw new TypeError('invalid-compute-gateways');
 		return parsed;
 	}
-	return development ? [DEFAULT_ARWEAVE_GATEWAY] : [...PRODUCTION_COMPUTE_GATEWAYS];
+	return [...PRODUCTION_COMPUTE_GATEWAYS];
 }
 
 export function computeGatewayForEnvironment(development: boolean, configured = configuredComputeGateway) {

--- a/src/routes/MyAssetsRoute.tsx
+++ b/src/routes/MyAssetsRoute.tsx
@@ -15,7 +15,7 @@ import {
 	verifyAssetCandidateSupport,
 	walletAssetGroups,
 } from 'api/asset-discovery';
-import { liquidBalanceOf, listedBalanceOf, servingNodeOrigin } from 'api/asset-marketplace';
+import { liquidBalanceOf, listedBalanceOf, liveOrdersOfAsset, servingNodeOrigin } from 'api/asset-marketplace';
 import { DISPLAY_STATE_CACHE, readAssetStateCached } from 'api/asset-state-store';
 
 import { Button } from 'components/Button';
@@ -39,6 +39,7 @@ import {
 	MarketContext,
 	MarketSelect,
 	nextWalletAnnouncementProgress,
+	orderPriceLabel,
 	refreshCandidateRetryMetadata,
 	reopenWalletCandidate,
 	RouteState,
@@ -682,6 +683,12 @@ export default function MyAssetsRoute() {
 	);
 }
 
+export function listedUniquePrice(result: ResolvedAsset, address: string): string | undefined {
+	if (result.collection.kind === 'tokens') return undefined;
+	const order = liveOrdersOfAsset(result.state).find((candidate) => candidate.creator === address);
+	return order ? orderPriceLabel(order, result.state) : undefined;
+}
+
 const AssetGroup = React.memo(function AssetGroup({
 	title,
 	results,
@@ -744,6 +751,7 @@ const AssetGroup = React.memo(function AssetGroup({
 						{results.slice(0, limit).map((result, index) => {
 							const listed = walletAssetGroups(result, address).includes('listed');
 							const listedBalance = listedBalanceOf(result.state, address);
+							const uniquePrice = listed ? listedUniquePrice(result, address) : undefined;
 							const balance =
 								view === 'listed'
 									? listedBalance
@@ -762,8 +770,9 @@ const AssetGroup = React.memo(function AssetGroup({
 											? `${tokenBalanceLabel(balance, result.state)}${
 													view === 'listed' ? ' listed' : ''
 											  }`
-											: undefined
+											: uniquePrice
 									}
+									priceListed={Boolean(uniquePrice)}
 								/>
 							);
 						})}

--- a/src/routes/MyAssetsRoute.tsx
+++ b/src/routes/MyAssetsRoute.tsx
@@ -53,8 +53,6 @@ import {
 	walletDiscoverySession,
 	walletDiscoverySessionIsCurrent,
 	walletResolutionCopy,
-	walletResolutionIsDeterminate,
-	walletResolutionShowsProgress,
 	type WalletResolutionStatus,
 } from '../app/App';
 import {
@@ -578,12 +576,6 @@ export default function MyAssetsRoute({
 		},
 		aggregateFailureMessage
 	);
-	const resolutionDeterminate = walletResolutionIsDeterminate(status);
-	const resolutionProgressTotal = status.phase === 'revalidating' ? status.revalidationTotal ?? 0 : status.total;
-	const resolutionProgressValue = status.phase === 'revalidating' ? status.revalidated ?? 0 : status.resolved;
-	const resolutionProgress = resolutionProgressTotal
-		? Math.min(100, Math.round((resolutionProgressValue / resolutionProgressTotal) * 100))
-		: 0;
 	return (
 		<section className={pageClassName}>
 			{!embedded ? (
@@ -626,21 +618,6 @@ export default function MyAssetsRoute({
 						<Loading label={resolutionCopy.heading} />
 						<p>{resolutionCopy.announcement}</p>
 					</div>
-					{walletResolutionShowsProgress(status) ? (
-						<div
-							aria-label={resolutionCopy.heading}
-							aria-valuemax={resolutionDeterminate ? 100 : undefined}
-							aria-valuemin={resolutionDeterminate ? 0 : undefined}
-							aria-valuenow={resolutionDeterminate ? resolutionProgress : undefined}
-							aria-valuetext={resolutionCopy.announcement}
-							className={`resolution-track${resolutionDeterminate ? '' : ' indeterminate'}${
-								status.failures ? ' has-failures' : ''
-							}`}
-							role="progressbar"
-						>
-							<span style={resolutionDeterminate ? { width: `${resolutionProgress}%` } : undefined} />
-						</div>
-					) : null}
 				</div>
 			) : null}
 			{status.error ? (

--- a/src/routes/ProfileRoute.css
+++ b/src/routes/ProfileRoute.css
@@ -1,41 +1,80 @@
 .profile-page {
-	width: min(1120px, calc(100% - 40px));
+	width: 100%;
 	margin: 0 auto;
 	padding: 42px 0 72px;
 }
 .profile-page__hero {
-	overflow: hidden;
-	border: 1px solid var(--line);
-	border-radius: 14px;
 	background: var(--paper);
-	box-shadow: 0 18px 54px var(--shadow-soft);
 }
 .profile-page__identity {
 	min-width: 0;
 	display: flex;
 	align-items: center;
 	gap: 20px;
-	padding: 28px;
+	padding: 28px 0;
 }
 .profile-page__avatar {
-	border: 3px solid var(--paper);
-	box-shadow: 0 7px 24px var(--shadow-medium);
+	box-shadow: none;
+}
+.profile-page__avatar-button {
+	position: relative;
+	padding: 0;
+	flex: 0 0 auto;
+	overflow: hidden;
+	border: 0;
+	border-radius: 50%;
+	background: transparent;
+	cursor: pointer;
+}
+.profile-page__avatar-button:focus-visible {
+	outline: 2px solid var(--ink);
+	outline-offset: 4px;
+}
+.profile-page__avatar-edit {
+	position: absolute;
+	inset: 0;
+	display: grid;
+	place-items: center;
+	border-radius: 50%;
+	background: color-mix(in srgb, #000 66%, transparent);
+	color: #fff;
+	opacity: 0;
+	transition: opacity 160ms ease;
+}
+.profile-page__avatar-edit .ui-icon {
+	width: 20px;
+	height: 20px;
+}
+.profile-page__avatar-button:is(:hover, :focus-visible) .profile-page__avatar-edit {
+	opacity: 1;
 }
 .profile-page__heading {
 	min-width: 0;
 	flex: 1 1 auto;
 }
+.profile-page__title-row {
+	min-width: 0;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
 .profile-page__heading h1 {
-	margin: 2px 0 4px;
-	font-size: clamp(1.65rem, 4vw, 2.35rem);
-	font-weight: 500;
-	letter-spacing: -0.04em;
+	margin: 0 0 4px;
+	min-width: 0;
+	overflow: hidden;
+	font-size: var(--type-page-title);
+	line-height: 1;
+	letter-spacing: -0.025em;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.profile-page__edit-button {
+	flex: 0 0 auto;
 }
 .profile-page__eyebrow {
-	margin: 0;
+	margin: 0 0 12px;
 	color: var(--muted-subtle);
-	font-size: var(--type-small);
-	letter-spacing: 0.08em;
+	font: 400 var(--type-small) / 1.3 'DM Sans', sans-serif;
 }
 .profile-page__address {
 	max-width: 100%;
@@ -53,7 +92,7 @@
 }
 .profile-page__bio {
 	max-width: 740px;
-	margin: 0 28px 28px 140px;
+	margin: 0 0 28px 112px;
 	color: var(--muted);
 	font-size: var(--type-body);
 	line-height: 1.65;
@@ -86,15 +125,142 @@
 .profile-page__content {
 	margin-top: 24px;
 }
+.profile-page__content .profile-assets {
+	padding-top: 0;
+}
+.profile-page__content .profile-assets > .asset-group:first-of-type {
+	margin-top: 0;
+}
+.profile-edit-dialog {
+	width: min(560px, 100%);
+}
+.profile-edit-dialog h2 {
+	margin: 0;
+}
+.profile-edit-form {
+	display: grid;
+	gap: 20px;
+}
+.profile-edit-form label,
+.profile-edit-form__field {
+	display: grid;
+	gap: 8px;
+	color: var(--ink);
+	font-size: var(--type-small);
+	font-weight: 500;
+}
+.profile-edit-form label input {
+	width: 100%;
+	min-width: 0;
+	padding: 11px 12px;
+	border: 1px solid var(--line-dark);
+	border-radius: 8px;
+	color: var(--ink);
+	background: var(--paper);
+	font: inherit;
+	font-weight: 400;
+}
+.profile-edit-form label input:focus-visible {
+	border-color: var(--ink);
+	outline: 2px solid color-mix(in srgb, var(--ink) 18%, transparent);
+	outline-offset: 1px;
+}
+.profile-edit-form__note {
+	margin: 0;
+	color: var(--muted-subtle);
+	font-size: var(--type-small);
+	font-weight: 400;
+	line-height: 1.45;
+}
+.profile-edit-form__file-input {
+	display: none;
+}
+.profile-edit-dropzone {
+	position: relative;
+	width: 100%;
+	min-height: 168px;
+	padding: 0;
+	overflow: hidden;
+	display: grid;
+	place-items: center;
+	border: 1px dashed var(--line-dark);
+	border-radius: 9px;
+	background: var(--surface-subtle);
+	cursor: pointer;
+}
+.profile-edit-dropzone:is(:hover, :focus-visible),
+.profile-edit-dropzone.is-dragging {
+	border-color: var(--ink);
+	background: var(--surface-hover);
+}
+.profile-edit-dropzone:focus-visible {
+	outline: 2px solid color-mix(in srgb, var(--ink) 18%, transparent);
+	outline-offset: 2px;
+}
+.profile-edit-dropzone img {
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+}
+.profile-edit-dropzone__prompt {
+	position: relative;
+	z-index: 1;
+	padding: 24px;
+	display: grid;
+	justify-items: center;
+	gap: 7px;
+	color: var(--muted-subtle);
+	text-align: center;
+}
+.profile-edit-dropzone__prompt .ui-icon {
+	width: 22px;
+	height: 22px;
+}
+.profile-edit-dropzone__prompt strong {
+	color: var(--ink);
+	font-size: var(--type-body);
+	font-weight: 500;
+}
+.profile-edit-dropzone__prompt small {
+	font-size: var(--type-small);
+	font-weight: 400;
+}
+.profile-edit-dropzone.has-preview .profile-edit-dropzone__prompt {
+	width: 100%;
+	height: 100%;
+	align-content: center;
+	background: color-mix(in srgb, #000 62%, transparent);
+	color: color-mix(in srgb, #fff 78%, transparent);
+}
+.profile-edit-dropzone.has-preview .profile-edit-dropzone__prompt strong {
+	color: #fff;
+}
+.profile-edit-form__remove-picture {
+	width: max-content;
+	padding: 2px 0;
+	color: var(--muted);
+	font-size: var(--type-small);
+}
+.profile-edit-form__error {
+	margin: 0;
+	color: var(--danger);
+	font-size: var(--type-small);
+}
+.profile-edit-form__actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 10px;
+}
 @media (max-width: 640px) {
 	.profile-page {
-		width: min(100% - 24px, 1120px);
 		padding-top: 20px;
 	}
 	.profile-page__identity {
 		align-items: flex-start;
 		gap: 14px;
-		padding: 20px 18px;
+		padding: 20px 0;
 	}
 	.profile-page__avatar {
 		width: 72px;
@@ -107,7 +273,20 @@
 	}
 	.profile-page__bio {
 		margin-top: 24px;
-		margin-right: 18px;
-		margin-left: 18px;
+		margin-right: 0;
+		margin-left: 0;
+	}
+	.profile-edit-backdrop {
+		padding: 12px;
+		place-items: end center;
+	}
+	.profile-edit-dialog {
+		padding: 24px 20px;
+		border-radius: 12px;
+	}
+}
+@media (hover: none) {
+	.profile-page__avatar-edit {
+		opacity: 0.72;
 	}
 }

--- a/src/routes/ProfileRoute.test.tsx
+++ b/src/routes/ProfileRoute.test.tsx
@@ -34,4 +34,11 @@ describe('ProfileRoute', () => {
 		expect(markup).toContain('role="alert"');
 		expect(markup).toContain('Retry');
 	});
+
+	it('makes both the avatar and name edit control available to the owner', () => {
+		const markup = renderToStaticMarkup(<ProfilePage onEdit={() => undefined} profile={profile} />);
+
+		expect(markup).toContain('aria-label="Edit profile picture"');
+		expect(markup).toContain('aria-label="Edit profile"');
+	});
 });

--- a/src/routes/ProfileRoute.tsx
+++ b/src/routes/ProfileRoute.tsx
@@ -1,10 +1,22 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import { MapPin } from 'lucide-react';
+import { Camera, MapPin, Pencil, Upload, X } from 'lucide-react';
 
-import { profileAvatarUrl, profileDisplayName, readAccountProfile } from 'api/profile';
+import {
+	profileAvatarUrl,
+	PROFILE_AVATAR_CONTENT_TYPES,
+	PROFILE_AVATAR_MAX_BYTES,
+	ProfileClient,
+	profileDisplayName,
+	readAccountProfile,
+	type ProfileUpdate,
+} from 'api/profile';
 
+import { Button } from 'components/Button';
 import { ProfileAvatar, type ProfileSummary, shortProfileAddress } from 'components/ProfileIdentity';
+import { useWallet } from 'providers/WalletProvider';
+
+import { useDialogFocus } from '../app/useDialogFocus';
 
 import './ProfileRoute.css';
 
@@ -16,20 +28,56 @@ export type ProfileRouteProps = {
 	error?: string | null;
 	isLoading?: boolean;
 	onRetry?: () => void;
+	onEdit?: (trigger: HTMLButtonElement) => void;
 	profile: ProfileSummary;
 };
 
-export function ProfilePage({ action, children, error, isLoading = false, onRetry, profile }: ProfileRouteProps) {
+export function ProfilePage({
+	action,
+	children,
+	error,
+	isLoading = false,
+	onEdit,
+	onRetry,
+	profile,
+}: ProfileRouteProps) {
 	const name = profile.displayName?.trim() || shortProfileAddress(profile.address);
 
 	return (
 		<section className="profile-page">
 			<section className="profile-page__hero" aria-labelledby="profile-page-title">
 				<div className="profile-page__identity">
-					<ProfileAvatar className="profile-page__avatar" profile={profile} size="large" />
+					{onEdit ? (
+						<button
+							aria-label="Edit profile picture"
+							className="profile-page__avatar-button"
+							onClick={(event) => onEdit(event.currentTarget)}
+							type="button"
+						>
+							<ProfileAvatar className="profile-page__avatar" profile={profile} size="large" />
+							<span aria-hidden="true" className="profile-page__avatar-edit">
+								<Camera className="ui-icon" />
+							</span>
+						</button>
+					) : (
+						<ProfileAvatar className="profile-page__avatar" profile={profile} size="large" />
+					)}
 					<div className="profile-page__heading">
 						<p className="profile-page__eyebrow">Arweave profile</p>
-						<h1 id="profile-page-title">{name}</h1>
+						<div className="profile-page__title-row">
+							<h1 id="profile-page-title">{name}</h1>
+							{onEdit ? (
+								<Button
+									aria-label="Edit profile"
+									className="profile-page__edit-button"
+									onClick={(event) => onEdit(event.currentTarget)}
+									size="icon"
+									variant="ghost"
+								>
+									<Pencil aria-hidden="true" className="ui-icon" />
+								</Button>
+							) : null}
+						</div>
 						<p className="profile-page__address" title={profile.address}>
 							{profile.address}
 						</p>
@@ -59,13 +107,251 @@ export function ProfilePage({ action, children, error, isLoading = false, onRetr
 	);
 }
 
+type ProfileEditUpdate = {
+	displayName: string;
+	displayNameChanged: boolean;
+	avatarFile: File | null;
+	removeAvatar: boolean;
+};
+
+function ProfileEditDialog({
+	onClose,
+	onSave,
+	open,
+	profile,
+	restoreTarget,
+}: {
+	onClose(): void;
+	onSave(update: ProfileEditUpdate, onStatus: (status: string) => void): Promise<void>;
+	open: boolean;
+	profile: ProfileSummary;
+	restoreTarget(): HTMLElement | null;
+}) {
+	const [displayName, setDisplayName] = React.useState('');
+	const [avatarFile, setAvatarFile] = React.useState<File | null>(null);
+	const [avatarPreview, setAvatarPreview] = React.useState('');
+	const [dragging, setDragging] = React.useState(false);
+	const [removeAvatar, setRemoveAvatar] = React.useState(false);
+	const [status, setStatus] = React.useState('');
+	const [error, setError] = React.useState('');
+	const fileInput = React.useRef<HTMLInputElement>(null);
+	const busy = Boolean(status);
+	const displayNameChanged = displayName.trim() !== (profile.displayName ?? '').trim();
+	const pictureChanged = Boolean(avatarFile) || removeAvatar;
+	const close = React.useCallback(() => {
+		if (!busy) onClose();
+	}, [busy, onClose]);
+	const dialogRef = useDialogFocus<HTMLDivElement>(open, close, restoreTarget);
+
+	React.useEffect(() => {
+		if (!open) return;
+		setDisplayName(profile.displayName ?? '');
+		setAvatarFile(null);
+		setAvatarPreview(profile.avatar ?? '');
+		setDragging(false);
+		setRemoveAvatar(false);
+		setStatus('');
+		setError('');
+	}, [open, profile.avatar, profile.displayName]);
+
+	React.useEffect(() => {
+		if (!avatarFile) {
+			setAvatarPreview(removeAvatar ? '' : profile.avatar ?? '');
+			return;
+		}
+		const url = URL.createObjectURL(avatarFile);
+		setAvatarPreview(url);
+		return () => URL.revokeObjectURL(url);
+	}, [avatarFile, profile.avatar, removeAvatar]);
+
+	if (!open) return null;
+
+	const submit = async (event: React.FormEvent) => {
+		event.preventDefault();
+		setError('');
+		setStatus(avatarFile ? 'Preparing picture…' : 'Preparing profile…');
+		try {
+			await onSave({ displayName, displayNameChanged, avatarFile, removeAvatar }, setStatus);
+		} catch (cause) {
+			setStatus('');
+			setError(profileUpdateError(cause));
+		}
+	};
+	const selectAvatar = (file: File | null) => {
+		if (!file) return;
+		const validationError = profileImageError(file);
+		if (validationError) {
+			setAvatarFile(null);
+			setRemoveAvatar(false);
+			setError(validationError);
+			return;
+		}
+		setError('');
+		setAvatarFile(file);
+		setRemoveAvatar(false);
+	};
+
+	return (
+		<div
+			className="dialog-backdrop profile-edit-backdrop"
+			onMouseDown={(event) => event.target === event.currentTarget && close()}
+			role="presentation"
+		>
+			<section
+				aria-labelledby="profile-edit-title"
+				aria-modal="true"
+				className="dialog dialog-compact profile-edit-dialog"
+				ref={dialogRef}
+				role="dialog"
+				tabIndex={-1}
+			>
+				<div className="dialog-heading">
+					<div>
+						<p className="eyebrow">Your public identity</p>
+						<h2 id="profile-edit-title">Edit profile</h2>
+					</div>
+					<Button
+						aria-label="Close profile editor"
+						disabled={busy}
+						onClick={close}
+						size="icon"
+						variant="ghost"
+					>
+						<X aria-hidden="true" className="ui-icon" />
+					</Button>
+				</div>
+				<form className="profile-edit-form" onSubmit={(event) => void submit(event)}>
+					<label>
+						<span>Profile name</span>
+						<input
+							autoComplete="nickname"
+							autoFocus
+							disabled={busy}
+							maxLength={64}
+							onChange={(event) => setDisplayName(event.target.value)}
+							placeholder="How people will see you"
+							value={displayName}
+						/>
+					</label>
+					<div className="profile-edit-form__field">
+						<span>Profile picture</span>
+						<input
+							accept="image/png,image/jpeg,image/webp,image/gif"
+							className="profile-edit-form__file-input"
+							disabled={busy}
+							onChange={(event) => {
+								selectAvatar(event.target.files?.[0] ?? null);
+								event.target.value = '';
+							}}
+							ref={fileInput}
+							type="file"
+						/>
+						<Button
+							aria-label={avatarPreview ? 'Change profile picture' : 'Choose profile picture'}
+							className={`profile-edit-dropzone${dragging ? ' is-dragging' : ''}${
+								avatarPreview ? ' has-preview' : ''
+							}`}
+							disabled={busy}
+							onClick={() => fileInput.current?.click()}
+							onDragEnter={(event) => {
+								event.preventDefault();
+								setDragging(true);
+							}}
+							onDragLeave={(event) => {
+								const next = event.relatedTarget;
+								if (!(next instanceof Node) || !event.currentTarget.contains(next)) setDragging(false);
+							}}
+							onDragOver={(event) => {
+								event.preventDefault();
+								setDragging(true);
+							}}
+							onDrop={(event) => {
+								event.preventDefault();
+								setDragging(false);
+								selectAvatar(event.dataTransfer.files?.[0] ?? null);
+							}}
+							size="custom"
+						>
+							{avatarPreview ? <img alt="Profile picture preview" src={avatarPreview} /> : null}
+							<span className="profile-edit-dropzone__prompt">
+								<Upload aria-hidden="true" className="ui-icon" />
+								<strong>{avatarPreview ? 'Drop or choose a new image' : 'Drop an image here'}</strong>
+								<small>PNG, JPEG, WebP, or GIF · up to 10 MB</small>
+							</span>
+						</Button>
+						{avatarPreview ? (
+							<Button
+								className="profile-edit-form__remove-picture"
+								disabled={busy}
+								onClick={() => {
+									setAvatarFile(null);
+									setRemoveAvatar(true);
+								}}
+								size="custom"
+								variant="ghost"
+							>
+								Remove picture
+							</Button>
+						) : null}
+					</div>
+					{error ? (
+						<p className="profile-edit-form__error" role="alert">
+							{error}
+						</p>
+					) : null}
+					<p className="profile-edit-form__note">
+						Your profile is saved permanently on Arweave. A new picture may require two wallet approvals.
+					</p>
+					<div className="profile-edit-form__actions">
+						<Button disabled={busy} onClick={close} variant="ghost">
+							Cancel
+						</Button>
+						<Button
+							disabled={busy || (!displayNameChanged && !pictureChanged)}
+							type="submit"
+							variant="primary"
+						>
+							{status || 'Save profile'}
+						</Button>
+					</div>
+				</form>
+			</section>
+		</div>
+	);
+}
+
+function profileImageError(file: File) {
+	if (!PROFILE_AVATAR_CONTENT_TYPES.includes(file.type)) return 'Choose a PNG, JPEG, WebP, or GIF image.';
+	if (!file.size || file.size > PROFILE_AVATAR_MAX_BYTES) return 'Choose an image smaller than 10 MB.';
+	return '';
+}
+
+function profileUpdateError(cause: unknown) {
+	if (cause instanceof Error && cause.message === 'invalid-profile-avatar') {
+		return 'The existing profile picture is not a valid image reference. Choose a new picture and try again.';
+	}
+	if (cause instanceof Error && cause.message === 'invalid-profile-avatar-type') {
+		return 'Choose a PNG, JPEG, WebP, or GIF image.';
+	}
+	if (cause instanceof Error && cause.message === 'invalid-profile-avatar-size') {
+		return 'Choose an image smaller than 10 MB.';
+	}
+	if (cause instanceof Error && cause.message === 'wallet-account-changed') {
+		return 'The connected wallet changed. Return to your current wallet profile and try again.';
+	}
+	return 'Your profile could not be updated. Please try again.';
+}
+
 const ADDRESS = /^[A-Za-z0-9_-]{43}$/;
 
 export default function ProfileRoute() {
 	const { address = '' } = useParams();
+	const wallet = useWallet();
 	const [retry, setRetry] = React.useState(0);
 	const [profile, setProfile] = React.useState<Awaited<ReturnType<typeof readAccountProfile>>>();
 	const [error, setError] = React.useState('');
+	const [editOpen, setEditOpen] = React.useState(false);
+	const editTrigger = React.useRef<HTMLButtonElement | null>(null);
 
 	React.useEffect(() => {
 		setError('');
@@ -92,14 +378,45 @@ export default function ProfileRoute() {
 		...(profile?.bio ? { bio: profile.bio } : {}),
 		...(profileAvatarUrl(profile) ? { avatar: profileAvatarUrl(profile) } : {}),
 	};
+	const openEditor = (trigger: HTMLButtonElement) => {
+		editTrigger.current = trigger;
+		setEditOpen(true);
+	};
+	const saveProfile = async (update: ProfileEditUpdate, onStatus: (status: string) => void) => {
+		const client = new ProfileClient();
+		const fields: ProfileUpdate = update.displayNameChanged ? { displayName: update.displayName } : {};
+		if (update.removeAvatar) fields.avatar = '';
+		if (update.avatarFile) {
+			const data = new Uint8Array(await update.avatarFile.arrayBuffer());
+			fields.avatar = await client.uploadAvatar(address, data, update.avatarFile.type, {
+				onPhase: (phase) => onStatus(phase === 'signing' ? 'Approve picture…' : 'Uploading picture…'),
+			});
+		}
+		onStatus('Preparing profile…');
+		const updated = await client.update(address, fields, {
+			onPhase: (phase) => onStatus(phase === 'signing' ? 'Approve profile…' : 'Publishing profile…'),
+		});
+		setProfile(updated);
+		setEditOpen(false);
+	};
 	return (
-		<ProfilePage
-			error={error}
-			isLoading={ADDRESS.test(address) && profile === undefined && !error}
-			onRetry={() => setRetry((value) => value + 1)}
-			profile={summary}
-		>
-			{ADDRESS.test(address) ? <MyAssetsRoute address={address} embedded /> : null}
-		</ProfilePage>
+		<>
+			<ProfilePage
+				error={error}
+				isLoading={ADDRESS.test(address) && profile === undefined && !error}
+				onEdit={wallet.address === address ? openEditor : undefined}
+				onRetry={() => setRetry((value) => value + 1)}
+				profile={summary}
+			>
+				{ADDRESS.test(address) ? <MyAssetsRoute address={address} embedded /> : null}
+			</ProfilePage>
+			<ProfileEditDialog
+				onClose={() => setEditOpen(false)}
+				onSave={saveProfile}
+				open={editOpen}
+				profile={summary}
+				restoreTarget={() => editTrigger.current}
+			/>
+		</>
 	);
 }


### PR DESCRIPTION
## Summary

- preserve transaction observer and mining progress across reloads, with clearer confirmation activity and recovery status
- improve fungible holder, receipt, tooltip, Unique pricing, gateway peer, and marketplace layout presentation
- add editable wallet profiles with permanent avatar uploads and align local compute defaults with production peers

## Validation

- `git diff --check`
- `npm test -- --maxWorkers=2` (796 tests passed)
- `npm run build`
- Prettier checks for the changed files
- clean dry merge against current `origin/edge`

The local-only screenshot artwork override is intentionally excluded from this branch and PR.